### PR TITLE
feat: rest api provider

### DIFF
--- a/group-generators/helpers/providers/index.ts
+++ b/group-generators/helpers/providers/index.ts
@@ -2,6 +2,7 @@ import BigQueryProvider from "./big-query/big-query";
 import { GraphQLProvider } from "./graphql";
 import { LensProvider } from "./lens";
 import { PoapSubgraphProvider } from "./poap";
+import { RESTProvider } from "./rest-api";
 import { SnapshotProvider } from "./snapshot";
 import { SubgraphHostedServiceProvider } from "./subgraph";
 
@@ -12,4 +13,5 @@ export const dataProviders = {
   SubgraphHostedServiceProvider,
   PoapSubgraphProvider,
   LensProvider,
+  RESTProvider,
 };

--- a/group-generators/helpers/providers/rest-api/index.ts
+++ b/group-generators/helpers/providers/rest-api/index.ts
@@ -1,0 +1,23 @@
+import axios, { AxiosResponse } from "axios";
+import { ApiConfig } from "./types";
+
+export class RESTProvider {
+  /**
+   * Use this method to query any rest api.
+   * @param options Used to pass api config like api url & method of the request.
+   * @returns The data of the api request
+   */
+  public async fetchData(options: ApiConfig): Promise<AxiosResponse> {
+    try {
+      const { data } = await axios({
+        url: options.url,
+        method: options.method,
+        data: options.data,
+      });
+      return data;
+    } catch (error) {
+      console.log(error);
+      throw new Error("Failed to fetch data...");
+    }
+  }
+}

--- a/group-generators/helpers/providers/rest-api/index.ts
+++ b/group-generators/helpers/providers/rest-api/index.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosResponse } from "axios";
 import { ApiConfig } from "./types";
 
-export class RESTProvider {
+class RESTProvider {
   /**
    * Use this method to query any rest api.
    * @param options Used to pass api config like api url & method of the request.
@@ -21,3 +21,5 @@ export class RESTProvider {
     }
   }
 }
+
+export { RESTProvider, ApiConfig };

--- a/group-generators/helpers/providers/rest-api/types.ts
+++ b/group-generators/helpers/providers/rest-api/types.ts
@@ -1,9 +1,11 @@
+import { Method } from "axios";
+
 export type ApiConfig = {
   // `url` is the api URL that will be used for the request
   url: string;
 
   // `method` is the request method to be used when making the request
-  method: string;
+  method: Method;
 
   // `data` is the data to be sent as the request body
   data: object;

--- a/group-generators/helpers/providers/rest-api/types.ts
+++ b/group-generators/helpers/providers/rest-api/types.ts
@@ -1,0 +1,10 @@
+export type ApiConfig = {
+  // `url` is the api URL that will be used for the request
+  url: string;
+
+  // `method` is the request method to be used when making the request
+  method: string;
+
+  // `data` is the data to be sent as the request body
+  data: object;
+};


### PR DESCRIPTION
## RESTProvider
This PR adds a new provider that makes it easy to send requests to any rest API. 

### How to use this provider:

- Create a new instance of the `RESTProvider` class

  ```
  const restProvider = new dataProviders.RESTProvider();
   ```

- Define your API config:

    Example:
    ```
    const ApiConfig = { 
      url: "https://lil-noun-api.fly.dev/ideas", 
      method: "GET",
      data: {},
    };```

- Use the created instance to access the public method `fetchData()` and pass ApiConfig as a parameter
   Like this:
   ```
   const response = await restProvider.fetchData(ApiConfig);
   ```
