### PR TITLE
add rest api provider

### DIFF
--- a/group-generators/helpers/providers/index.ts
+++ b/group-generators/helpers/providers/index.ts
@@ -2,6 +2,7 @@ import BigQueryProvider from "./big-query/big-query";
 import { GraphQLProvider } from "./graphql";
 import { LensProvider } from "./lens";
 import { PoapSubgraphProvider } from "./poap";
+import { RESTProvider } from "./rest-api";
 import { SnapshotProvider } from "./snapshot";
 import { SubgraphHostedServiceProvider } from "./subgraph";
 
@@ -12,4 +13,5 @@ export const dataProviders = {
   SubgraphHostedServiceProvider,
   PoapSubgraphProvider,
   LensProvider,
+  RESTProvider,
 };

--- a/group-generators/helpers/providers/rest-api/index.ts
+++ b/group-generators/helpers/providers/rest-api/index.ts
@@ -1,0 +1,25 @@
+import axios, { AxiosResponse } from "axios";
+import { ApiConfig } from "./types";
+
+class RESTProvider {
+  /**
+   * Use this method to query any rest api.
+   * @param options Used to pass api config like api url & method of the request.
+   * @returns The data of the api request
+   */
+  public async fetchData(options: ApiConfig): Promise<AxiosResponse> {
+    try {
+      const { data } = await axios({
+        url: options.url,
+        method: options.method,
+        data: options.data,
+      });
+      return data;
+    } catch (error) {
+      console.log(error);
+      throw new Error("Failed to fetch data...");
+    }
+  }
+}
+
+export { RESTProvider, ApiConfig };

--- a/group-generators/helpers/providers/rest-api/types.ts
+++ b/group-generators/helpers/providers/rest-api/types.ts
@@ -1,0 +1,12 @@
+import { Method } from "axios";
+
+export type ApiConfig = {
+  // `url` is the api URL that will be used for the request
+  url: string;
+
+  // `method` is the request method to be used when making the request
+  method: Method;
+
+  // `data` is the data to be sent as the request body
+  data: object;
+};

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@typedorm/document-client": "^1.15.0",
     "aws-lambda": "^1.0.7",
     "aws-sdk": "^2.1212.0",
+    "axios": "^0.27.2",
     "commander": "^9.4.0",
     "defender-relay-client": "^1.28.1",
     "ethers": "^5.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2858,6 +2858,14 @@ axios@^0.21.1, axios@^0.21.2:
   dependencies:
     follow-redirects "^1.14.0"
 
+axios@^0.27.2:
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
+  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
+  dependencies:
+    follow-redirects "^1.14.9"
+    form-data "^4.0.0"
+
 b4a@^1.0.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/b4a/-/b4a-1.6.0.tgz#5430a9cac1af388910dd1a1c1aa9d3a0a796ed68"
@@ -4806,7 +4814,7 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.6.tgz#022e9218c637f9f3fc9c35ab9c9193f05add60b2"
   integrity sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==
 
-follow-redirects@^1.14.0:
+follow-redirects@^1.14.0, follow-redirects@^1.14.9:
   version "1.15.1"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
   integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==


### PR DESCRIPTION
## RESTProvider
This PR adds a new provider that makes it easy to send requests to any rest API. 

### How to use this provider:

- Create a new instance of the `RESTProvider` class

  ```
  const restProvider = new dataProviders.RESTProvider();
   ```

- Define your API config & use the type `ApiConfig` from RestProvider types:

    Example:
    ```
    const ApiConfig: ApiConfig = { 
      url: "https://lil-noun-api.fly.dev/ideas", 
      method: 'GET',
      data: {},
    };
    ```

- Use the created instance to access the public method `fetchData()` and pass ApiConfig as a parameter
   Like this:
   ```
   const response = await restProvider.fetchData(ApiConfig);
   ```
