### PR TITLE
fix: reformatting githubProvider arguments as other providers

### DIFF
--- a/group-generators/generators/sismo-hub-contributors-github/index.ts
+++ b/group-generators/generators/sismo-hub-contributors-github/index.ts
@@ -14,16 +14,16 @@ const generator: GroupGenerator = {
 
     const sismoHubContributors =
       await githubProvider.getRepositoriesContributors(
-        ["sismo-core/sismo-hub"],
+        { repositories: ["sismo-core/sismo-hub"] },
         {
           getOrganizationMembers: true,
         },
         2
       );
 
-    const sismoHubStargazers = await githubProvider.getRepositoriesStargazers([
-      "sismo-core/sismo-hub",
-    ]);
+    const sismoHubStargazers = await githubProvider.getRepositoriesStargazers({
+      repositories: ["sismo-core/sismo-hub"],
+    });
 
     const sismoHubData = dataOperators.Union([
       sismoHubStargazers,

--- a/group-generators/generators/sismo-stargazers/index.ts
+++ b/group-generators/generators/sismo-stargazers/index.ts
@@ -11,9 +11,9 @@ const generator: GroupGenerator = {
   generate: async (context: GenerationContext): Promise<GroupWithData[]> => {
     const githubProvider = new dataProviders.GithubProvider();
 
-    const sismoStargazers = await githubProvider.getRepositoriesStargazers([
+    const sismoStargazers = await githubProvider.getRepositoriesStargazers({repositories : [
       "sismo-core/sismo-protocol",
-    ]);
+    ]});
 
     return [
       {

--- a/group-generators/generators/tuto-ens-contributors/index.ts
+++ b/group-generators/generators/tuto-ens-contributors/index.ts
@@ -20,10 +20,9 @@ const generator: GroupGenerator = {
     // 2. Instantiate Github Provider
     const githubProvider = new dataProviders.GithubProvider();
     // Query all contributors of ens and ens-contracts repositories
-    const contributors = await githubProvider.getRepositoriesContributors([
-      "ensdomains/ens",
-      "ensdomains/ens-contracts",
-    ]);
+    const contributors = await githubProvider.getRepositoriesContributors({
+      repositories: ["ensdomains/ens", "ensdomains/ens-contracts"],
+    });
 
     // 3. Make a union of the two queried data
     const tutorialEnsContributors = dataOperators.Union([voters, contributors]);

--- a/group-generators/helpers/data-providers/github/github.types.ts
+++ b/group-generators/helpers/data-providers/github/github.types.ts
@@ -22,7 +22,7 @@ export type GithubUserAPI = {
   contributions: number;
 };
 
-export type GithubRepositories = string[];
+export type GithubRepositories = { repositories: string[] };
 
 export type getRepositoryContributorsOptions = {
   getOrganizationMembers: boolean;

--- a/group-generators/helpers/data-providers/github/index.ts
+++ b/group-generators/helpers/data-providers/github/index.ts
@@ -41,7 +41,7 @@ export class GithubProvider {
     defaultValue = 1
   ): Promise<FetchedData> {
     const allRepositories: GithubLogin[][] = [];
-    for (const repo of repositories) {
+    for (const repo of repositories.repositories) {
       const organization = repo.split("/")[0];
       console.log(`Fetching ${organization}...`);
       allRepositories.push(await this._getRepositoryCommiters(repo));
@@ -69,7 +69,7 @@ export class GithubProvider {
     defaultValue = 1
   ): Promise<FetchedData> {
     const allRepositories: GithubLogin[][] = [];
-    for (const repo of repositories) {
+    for (const repo of repositories.repositories) {
       const organization = repo.split("/")[0];
       console.log(`Fetching ${organization}...`);
       allRepositories.push(await this._getRepositoryStargazers(repo));


### PR DESCRIPTION
Formatting Github provider helper arguments to match other providers and adjusting corresponding group generators