### PR TITLE
Update for Sismo API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ coverage
 .env*
 /log
 .DS_Store
+.yarn
+.yarnrc.yml

--- a/src/topics/badge/badge.api.schema.ts
+++ b/src/topics/badge/badge.api.schema.ts
@@ -102,6 +102,11 @@ const badge = {
       example: "10001",
     },
     network: network,
+    networks: {
+      type: "array",
+      description: "List of networks on which the badge exist",
+      items: network
+    },
     attributes: {
       type: "array",
       description: "Badge attributes",
@@ -129,6 +134,17 @@ const badge = {
   },
 } as const;
 
+
+const badgeNotFound = {
+  description: "Badge not found",
+  type: "object",
+  properties: {
+    message: {
+      type: "string",
+    },
+  },
+} as const;
+
 export const badgeRoutesSchemas = {
   networkList: {
     description: "List badges for a specific network",
@@ -151,7 +167,7 @@ export const badgeRoutesSchemas = {
       },
     },
   },
-  get: {
+  metadata: {
     description: "Get badge metadata",
     params: {
       type: "object",
@@ -166,15 +182,34 @@ export const badgeRoutesSchemas = {
     },
     response: {
       200: badge,
-      404: {
-        description: "Badge not found",
+      404: badgeNotFound,
+    },
+  },
+  get: {
+    description: "Get badge metadata",
+    params: {
+      type: "object",
+      required: ["network", "collectionId"],
+      properties: {
+        network: network,
+        collectionId: {
+          type: "string",
+          description: "Badge collection id",
+        },
+      },
+    },
+    response: {
+      200: {
+        description: "Badge metadata",
         type: "object",
         properties: {
-          message: {
-            type: "string",
+          items: {
+            type: "array",
+            items: badge,
           },
         },
       },
+      404: badgeNotFound,
     },
   },
 } as const;

--- a/src/topics/badge/badge.api.test.ts
+++ b/src/topics/badge/badge.api.test.ts
@@ -6,9 +6,7 @@ describe("test badges api - list network badges", () => {
     .getApiService(false)
     .getApi();
 
-  beforeAll(async () => {
-    await api.ready();
-  });
+  beforeAll(() => api.ready());
 
   it("should return bad request for invalid network name", async () => {
     const response = await request(api.server).get(`/badges/not-found/`);
@@ -27,6 +25,7 @@ describe("test badges api - list network badges", () => {
     expect(response.body.items).toHaveLength(3);
     expect(response.body.items[0].collectionId).not.toBe("");
     expect(response.body.items[0].network).toBe("test");
+    expect(response.body.items[0].networks).toEqual(["test"]);
     expect(response.body.items[0].attributes[0]).toEqual({
       trait_type: "PRIVACY",
       value: "Very High",
@@ -35,6 +34,8 @@ describe("test badges api - list network badges", () => {
     expect(response.body.items[1].collectionId).not.toBe("");
     expect(response.body.items[1].network).toBe("test");
     expect(response.body.items[1].isCurated).toEqual(false);
+
+    expect(response.body.items[2].networks).toEqual(["local", "test"])
   });
 });
 
@@ -42,9 +43,8 @@ describe("test badges api - specific badge", () => {
   const api = ServiceFactory.withDefault(ConfigurationDefaultEnv.Test, {})
     .getApiService(false)
     .getApi();
-  beforeAll(async () => {
-    await api.ready();
-  });
+  
+  beforeAll(() => api.ready());
 
   it("should return 404 for not existing badge", async () => {
     const response = await request(api.server).get(`/badges/test/123456.json`);
@@ -81,7 +81,9 @@ describe("test badges api - specific badge", () => {
   it("should return badge serialized (details/ route)", async () => {
     const response = await request(api.server).get(`/badges/test/details/1001`);
     expect(response.statusCode).toBe(200);
-    expect(response.body.name).toBe("Test Badge");
+    expect(response.body.items).toHaveLength(1);
     expect(Object.keys(response.body)).not.toContain("requirements");
+    const [badge] = response.body.items;
+    expect(badge.name).toBe("Test Badge");
   });
 });

--- a/src/topics/badge/badge.api.ts
+++ b/src/topics/badge/badge.api.ts
@@ -1,6 +1,6 @@
 import { BigNumber, ethers } from "ethers";
-import { badgeRoutesSchemas } from "./badge.api.schema";
-import { Badge } from ".";
+import { Badge } from "./badge";
+import { badgeRoutesSchemas as schemas } from "./badge.api.schema";
 import { Api, notFoundResponse } from "api";
 import { Network } from "topics/attester";
 
@@ -10,33 +10,29 @@ const setImageUrl = (api: Api, badge: Badge): Badge => ({
 });
 
 const routes = async (api: Api) => {
-  const getBadgesFromAttesters = (network: Network): Badge[] =>
-    api.badges.getBadges(network).map((badge) => setImageUrl(api, badge));
+  const getBadgesFromAttesters = (network: Network): Badge[] => {
+    return api.badges.getBadges(network).map((badge) => setImageUrl(api, badge));
+  }
 
-  api.get(
-    "/badges/:network/",
-    { schema: badgeRoutesSchemas.networkList },
-    (req) => ({ items: getBadgesFromAttesters(req.params.network) })
-  );
+  api.get("/badges/:network/", { schema: schemas.networkList }, (req) => { 
+    return { items: getBadgesFromAttesters(req.params.network) }
+  });
 
-  api.get(
-    "/badges/:network/:collectionId.json",
-    { schema: badgeRoutesSchemas.get },
-    async (req, res) =>
-      getBadgesFromAttesters(req.params.network).find(
-        (badge) =>
-          encodeCollectionId(badge.collectionId) == req.params.collectionId
-      ) || notFoundResponse(res, "Badge not found")
-  );
+  api.get("/badges/:network/:collectionId.json", { schema: schemas.metadata },(req, res) => {
+    const { network, collectionId } = req.params;
+    const badges = getBadgesFromAttesters(network);
+    const badge = badges.find((badge) => encodeCollectionId(badge.collectionId) === collectionId);
+    if (!badge) return notFoundResponse(res, "Badge not found");
+    return badge;
+  });
 
-  api.get(
-    "/badges/:network/details/:collectionId",
-    { schema: badgeRoutesSchemas.get },
-    async (req, res) =>
-      getBadgesFromAttesters(req.params.network).find(
-        (badge) => badge.collectionId.toString() == req.params.collectionId
-      ) || notFoundResponse(res, "Badge not found")
-  );
+  api.get("/badges/:network/details/:collectionId", { schema: schemas.get }, (req, res) => {
+    const { network, collectionId } = req.params;
+    const badges = getBadgesFromAttesters(network);
+    const badge = badges.find((badge) => badge.collectionId.toString() === collectionId);
+    if (!badge) return notFoundResponse(res, "Badge not found");
+    return { items: [badge] };
+  });
 };
 
 const encodeCollectionId = (collectionId: number): string =>


### PR DESCRIPTION
This PR update the badge api to : 
- output the `networks` field to the badge.
- `badges/:network/details/:collectionId` outputs a badge inside a single array `items` as the other endpoints

fix #801