### PR TITLE
feat: groups based on ethereum balances

### DIFF
--- a/group-generators/generators/ethereum-balances/index.ts
+++ b/group-generators/generators/ethereum-balances/index.ts
@@ -1,0 +1,49 @@
+import { dataOperators } from "@group-generators/helpers/data-operators";
+import { BigQueryProvider } from "@group-generators/helpers/data-providers/big-query/big-query";
+import { AccountSource, GroupWithData, Tags, ValueType } from "topics/group";
+import {
+  GenerationContext,
+  GenerationFrequency,
+  GroupGenerator,
+} from "topics/group-generator";
+
+const generator: GroupGenerator = {
+  generationFrequency: GenerationFrequency.Once,
+
+  generate: async (context: GenerationContext): Promise<GroupWithData[]> => {
+    const groups: GroupWithData[] = [];
+    const thresholds = [32, 64, 128];
+    const bigQueryProvider = new BigQueryProvider();
+
+    for (const threshold of thresholds) {
+      // returns 133,628 addresses for 32 ETH as of 16/03/2023
+      const query = `
+      SELECT
+        address, 1 as value
+      FROM
+        \`bigquery-public-data.crypto_ethereum.balances\`
+      WHERE
+        eth_balance >= ${threshold}000000000000000000.0;
+        `;
+
+      const richUsers = dataOperators.Map(
+        await bigQueryProvider.fetch(query),
+        1
+      );
+
+      groups.push({
+        name: `ethereum-balances-at-least-${threshold}`,
+        timestamp: context.timestamp,
+        description: `Ethereum users with at least ${threshold} ETH`,
+        specs: "Be Rich",
+        data: richUsers,
+        accountSources: [AccountSource.ETHEREUM],
+        valueType: ValueType.Score,
+        tags: [Tags.User, Tags.Mainnet],
+      });
+    }
+    return groups;
+  },
+};
+
+export default generator;

--- a/group-generators/generators/index.ts
+++ b/group-generators/generators/index.ts
@@ -119,6 +119,7 @@ import ethContributor from "./eth-contributor";
 import ethDegen from "./eth-degen";
 import eth2Depositors from "./eth2-depositors";
 import ethereumAdopter from "./ethereum-adopter";
+import ethereumRichUsers from "./ethereum-balances";
 import ethereumMostTransactions from "./ethereum-most-transactions";
 import ethereumPowerUsers from "./ethereum-power-users";
 import EthereumPowerUsersPolygonZkBadgeHolders from "./ethereum-power-users-polygon-zk-badge-holders";
@@ -492,7 +493,6 @@ import zkPayQuest from "./zkpay-quest";
 import zksyncGithubStargazers from "./zksync-github-stargazers";
 import zl019 from "./zl019";
 import zohalKYC from "./zohal-KYC";
-import ethereumRichUsers from "./ethereum-balances";
 
 export const groupGenerators: GroupGeneratorsLibrary = {
   "0xlegion-lens-follower": OxlegionLensFollower,

--- a/group-generators/generators/index.ts
+++ b/group-generators/generators/index.ts
@@ -324,7 +324,7 @@ import regenpunks from "./regenpunks";
 import rektFamillyDegen from "./rekt-familly-degen";
 import relayBadge from "./relay-badge";
 import retrodaoObolCollaboration from "./retrodao-obol-collaboration";
-import rhinofiPowerUsers from "./rhinofi-power-users";
+import rhinofiPowerUsers from "./rhinofi-power-users";  
 import ring from "./ring";
 import riobel from "./riobel";
 import roadtolife from "./roadtolife";
@@ -527,7 +527,7 @@ export const groupGenerators: GroupGeneratorsLibrary = {
   "balkaneros-in-antler": balkanerosInAntler,
   "banny": banny,
   "basile": basile,
-  "ben-friends": benFriends,
+  "ben-friends": benFriends, 
   "best-cafe": bestCafe,
   "bffe": bffe,
   "bgans": bgans,
@@ -618,6 +618,7 @@ export const groupGenerators: GroupGeneratorsLibrary = {
   "ethereum-most-transactions": ethereumMostTransactions,
   "ethereum-power-users": ethereumPowerUsers,
   "ethereum-power-users-polygon-zk-badge-holders": EthereumPowerUsersPolygonZkBadgeHolders,
+  "ethereum-rich-users": ethereumRichUsers,
   "etherium-eth-bit": etheriumEthBit,
   "etherium-eth-bit-5890": etheriumEthBit5890,
   "ethermail": ethermail,
@@ -818,7 +819,7 @@ export const groupGenerators: GroupGeneratorsLibrary = {
   "rekt-familly-degen": rektFamillyDegen,
   "relay-badge": relayBadge,
   "retrodao-obol-collaboration": retrodaoObolCollaboration,
-  "rhinofi-power-users": rhinofiPowerUsers,
+  "rhinofi-power-users": rhinofiPowerUsers, 
   "ring": ring,
   "riobel": riobel,
   "roadtolife": roadtolife,
@@ -987,5 +988,4 @@ export const groupGenerators: GroupGeneratorsLibrary = {
   "zksync-github-stargazers": zksyncGithubStargazers,
   "zl019": zl019,
   "zohal-KYC": zohalKYC,
-  "ethereum-rich-users": ethereumRichUsers,
 };

--- a/group-generators/generators/index.ts
+++ b/group-generators/generators/index.ts
@@ -323,7 +323,7 @@ import regenpunks from "./regenpunks";
 import rektFamillyDegen from "./rekt-familly-degen";
 import relayBadge from "./relay-badge";
 import retrodaoObolCollaboration from "./retrodao-obol-collaboration";
-import rhinofiPowerUsers from "./rhinofi-power-users";  
+import rhinofiPowerUsers from "./rhinofi-power-users";
 import ring from "./ring";
 import riobel from "./riobel";
 import roadtolife from "./roadtolife";
@@ -492,6 +492,7 @@ import zkPayQuest from "./zkpay-quest";
 import zksyncGithubStargazers from "./zksync-github-stargazers";
 import zl019 from "./zl019";
 import zohalKYC from "./zohal-KYC";
+import ethereumRichUsers from "./ethereum-balances";
 
 export const groupGenerators: GroupGeneratorsLibrary = {
   "0xlegion-lens-follower": OxlegionLensFollower,
@@ -526,7 +527,7 @@ export const groupGenerators: GroupGeneratorsLibrary = {
   "balkaneros-in-antler": balkanerosInAntler,
   "banny": banny,
   "basile": basile,
-  "ben-friends": benFriends, 
+  "ben-friends": benFriends,
   "best-cafe": bestCafe,
   "bffe": bffe,
   "bgans": bgans,
@@ -817,7 +818,7 @@ export const groupGenerators: GroupGeneratorsLibrary = {
   "rekt-familly-degen": rektFamillyDegen,
   "relay-badge": relayBadge,
   "retrodao-obol-collaboration": retrodaoObolCollaboration,
-  "rhinofi-power-users": rhinofiPowerUsers, 
+  "rhinofi-power-users": rhinofiPowerUsers,
   "ring": ring,
   "riobel": riobel,
   "roadtolife": roadtolife,
@@ -986,4 +987,5 @@ export const groupGenerators: GroupGeneratorsLibrary = {
   "zksync-github-stargazers": zksyncGithubStargazers,
   "zl019": zl019,
   "zohal-KYC": zohalKYC,
+  "ethereum-rich-users": ethereumRichUsers,
 };


### PR DESCRIPTION
We add 3 groups based on whether they have 32, 64 and 128 ETH.

This can be used for gate-keeping wealthy people.

32, 64, 128 ETH are arbitrary values. Currently 32 ETH threshold doesn't generate too many holders: around 130k.