### PR TITLE
Update OP ATST to allow for value scoring

### DIFF
--- a/group-generators/generators/ben-multiarg-group/index.ts
+++ b/group-generators/generators/ben-multiarg-group/index.ts
@@ -1,4 +1,3 @@
-
 import { dataOperators } from "@group-generators/helpers/data-operators";
 import { dataProviders } from "@group-generators/helpers/data-providers";
 import { Tags, ValueType, GroupWithData } from "topics/group";
@@ -11,25 +10,26 @@ import {
 // Generated from factory.sismo.io
 
 const generator: GroupGenerator = {
-  
   generationFrequency: GenerationFrequency.Once,
-  
+
   generate: async (context: GenerationContext): Promise<GroupWithData[]> => {
-  
-    const attestationStationProvider = new dataProviders.AttestationStationProvider();
-    
-    const attestationStationProviderData0 = await attestationStationProvider.getAttestations({
-      key: "numFollowersTwitter",
-      value: "1"
-    });
-    
+    const attestationStationProvider =
+      new dataProviders.AttestationStationProvider();
+
+    const attestationStationProviderData0 =
+      await attestationStationProvider.getAttestations({
+        creator: "0xd34a8775d06d41b36054d59ef2d09a79b7aa1fa2",
+        key: "numFollowersTwitter",
+        value: "1",
+      });
+
     const jsonListData1 = {
       "ben.eth": "1",
     };
-    
+
     const dataUnion = dataOperators.Union([
       attestationStationProviderData0,
-      jsonListData1 
+      jsonListData1,
     ]);
 
     return [

--- a/group-generators/generators/optimists/index.ts
+++ b/group-generators/generators/optimists/index.ts
@@ -25,7 +25,7 @@ const generator: GroupGenerator = {
           "Score up to 5 points by doing things that contribute to the Optimism Network. You can attest your score on-chain using the Optimist score by Flipside https://science.flipsidecrypto.xyz/optimist/",
         specs: "You need a perfect score of 5/5 points.",
         data: receivers,
-        valueType: ValueType.Score,
+        valueType: ValueType.Info,
         tags: [Tags.User, Tags.SybilResistance],
       },
     ];

--- a/group-generators/generators/optimists/index.ts
+++ b/group-generators/generators/optimists/index.ts
@@ -12,6 +12,7 @@ const generator: GroupGenerator = {
   generate: async (context: GenerationContext): Promise<GroupWithData[]> => {
     const provider = new AttestationStationProvider();
     const receivers = await provider.getAttestations({
+      creator: "0xd870a73a32d0b8c34ccf1e6098e9a26977cb605b",
       key: "Flipside_user_scoring",
       value: "\u0005",
     });
@@ -24,7 +25,7 @@ const generator: GroupGenerator = {
           "Attest your Optimist score on-chain with a perfect score of 5.",
         specs: "Score a perfect 5 point score on the Flipside Optimist score",
         data: receivers,
-        valueType: ValueType.Info,
+        valueType: ValueType.Score,
         tags: [Tags.User, Tags.SybilResistance],
       },
     ];

--- a/group-generators/generators/optimists/index.ts
+++ b/group-generators/generators/optimists/index.ts
@@ -22,8 +22,8 @@ const generator: GroupGenerator = {
         name: "optimists",
         timestamp: context.timestamp,
         description:
-          "Attest your Optimist score on-chain with a perfect score of 5.",
-        specs: "Score a perfect 5 point score on the Flipside Optimist score",
+          "Score up to 5 points by doing things that contribute to the Optimism Network. You can attest your score on-chain using the Optimist score by Flipside https://science.flipsidecrypto.xyz/optimist/",
+        specs: "You need a perfect score of 5/5 points.",
         data: receivers,
         valueType: ValueType.Score,
         tags: [Tags.User, Tags.SybilResistance],

--- a/group-generators/helpers/data-providers/atst/index.ts
+++ b/group-generators/helpers/data-providers/atst/index.ts
@@ -44,7 +44,7 @@ export class AttestationStationProvider extends GraphQLProvider {
     return dataProfiles;
   }
 
-  public async GetAttestationValueParams(
+  public async getAttestationValuesCount(
     params: GetAttestationValueParams
   ): Promise<number> {
     const attestations = await this.getAttestationValues(params);

--- a/group-generators/helpers/data-providers/atst/index.ts
+++ b/group-generators/helpers/data-providers/atst/index.ts
@@ -1,5 +1,9 @@
 import { defaultLimit, getAttestationsQuery } from "./queries";
-import { GetAttestationParams, QueryParams } from "./types";
+import {
+  GetAttestationParams,
+  GetAttestationValueParams,
+  QueryParams,
+} from "./types";
 import { GraphQLProvider } from "@group-generators/helpers/data-providers/graphql";
 import { FetchedData } from "topics/group";
 
@@ -10,23 +14,40 @@ export class AttestationStationProvider extends GraphQLProvider {
     });
   }
 
-  public async getAttestations({
-    key,
-    value,
-  }: GetAttestationParams): Promise<FetchedData> {
+  public async getAttestations(
+    params: GetAttestationParams
+  ): Promise<FetchedData> {
     const dataProfiles: FetchedData = {};
-    for await (const item of this._getAttestations({ key, value })) {
+    for await (const item of this._getAttestations(params)) {
       dataProfiles[item.receiver] = 1;
     }
 
     return dataProfiles;
   }
 
-  public async getAttestationsCount({
-    key,
-    value,
-  }: GetAttestationParams): Promise<number> {
-    const attestations = await this.getAttestations({ key, value });
+  public async getAttestationsCount(
+    params: GetAttestationParams
+  ): Promise<number> {
+    const attestations = await this.getAttestations(params);
+    return Object.keys(attestations).length;
+  }
+
+  public async getAttestationValues(
+    params: GetAttestationValueParams
+  ): Promise<FetchedData> {
+    const dataProfiles: FetchedData = {};
+    for await (const item of this._getAttestations(params)) {
+      const value = isNaN(Number(item.val)) ? 1 : Number(item.val);
+      dataProfiles[item.receiver] = value;
+    }
+
+    return dataProfiles;
+  }
+
+  public async GetAttestationValueParams(
+    params: GetAttestationValueParams
+  ): Promise<number> {
+    const attestations = await this.getAttestationValues(params);
     return Object.keys(attestations).length;
   }
 
@@ -37,12 +58,13 @@ export class AttestationStationProvider extends GraphQLProvider {
     while (hasNext) {
       const response = await getAttestationsQuery(this, {
         ...params,
-        skip: offset,
+        index: offset,
       });
 
       yield* response.attestations;
 
-      offset += defaultLimit;
+      offset =
+        response.attestations[response.attestations.length - 1]?.index ?? 0;
       hasNext = response.attestations.length === defaultLimit;
     }
   }

--- a/group-generators/helpers/data-providers/atst/interface-schema.json
+++ b/group-generators/helpers/data-providers/atst/interface-schema.json
@@ -4,24 +4,53 @@
   "providerClassName": "AttestationStationProvider",
   "functions": [
     {
-      "name": "Get attestation receivers",
+      "name": "Get receivers",
       "functionName": "getAttestations",
       "countFunctionName": "getAttestationsCount",
       "description": "Returns all the receivers of a specific attestation on AttestationStation",
       "args": [
         {
+          "name": "account",
+          "argName": "account",
+          "type": "string",
+          "example": "0xd870a73a32d0b8c34ccf1e6098e9a26977cb605b",
+          "description": "The creator of the attestation"
+        },
+        {
           "name": "key",
           "argName": "key",
           "type": "string",
-          "example": "numFollowersTwitter",
-          "description": "The key of a attestation"
+          "example": "Flipside_user_scoring",
+          "description": "The key of the attestation"
         },
         {
           "name": "value",
           "argName": "value",
           "type": "string",
-          "example": "1",
+          "example": "5",
           "description": "The required value for the attestation"
+        }
+      ]
+    },
+    {
+      "name": "Get attestation values",
+      "functionName": "getAttestationValues",
+      "countFunctionName": "getAttestationValuesCount",
+      "description": "Uses the values of the attestations if these are numeric. Otherwise counts as 1.",
+      "args": [
+        {
+          "name": "account",
+          "argName": "account",
+          "type": "string",
+          "example": "0xd870a73a32d0b8c34ccf1e6098e9a26977cb605b",
+          "description": "The creator of the attestation"
+        },
+        {
+          "name": "key",
+          "argName": "key",
+          "type": "string",
+          "example": "Flipside_user_scoring",
+          "description": "The key of the attestation"
         }
       ]
     }

--- a/group-generators/helpers/data-providers/atst/interface-schema.json
+++ b/group-generators/helpers/data-providers/atst/interface-schema.json
@@ -10,8 +10,8 @@
       "description": "Returns all the receivers of a specific attestation on AttestationStation",
       "args": [
         {
-          "name": "account",
-          "argName": "account",
+          "name": "creator",
+          "argName": "creator",
           "type": "string",
           "example": "0xd870a73a32d0b8c34ccf1e6098e9a26977cb605b",
           "description": "The creator of the attestation"
@@ -39,8 +39,8 @@
       "description": "Uses the values of the attestations if these are numeric. Otherwise counts as 1.",
       "args": [
         {
-          "name": "account",
-          "argName": "account",
+          "name": "creator",
+          "argName": "creator",
           "type": "string",
           "example": "0xd870a73a32d0b8c34ccf1e6098e9a26977cb605b",
           "description": "The creator of the attestation"

--- a/group-generators/helpers/data-providers/atst/queries.ts
+++ b/group-generators/helpers/data-providers/atst/queries.ts
@@ -12,15 +12,21 @@ export const getAttestationsQuery = async (
       {
         attestations(
           first: ${params.first ?? defaultLimit}
-          skip: ${params.skip ?? 0}
-          orderBy: blockTimestamp
-          orderDirection: desc
-          where: { keyString: "${params.key}", valueString: "${params.value}" }
+          orderBy: index
+          orderDirection: asc
+          where: { 
+            creator: "${params.creator}"
+            ${params.key ? `keyString: "${params.key}"` : ""}
+            ${params.value ? `valueString: "${params.value}"` : ""}
+            index_gte: ${params.index ?? 0}
+          }
         ) {
           id
+          index
           creator
           receiver
           keyString
+          val
           valueString
         }
       }

--- a/group-generators/helpers/data-providers/atst/types.ts
+++ b/group-generators/helpers/data-providers/atst/types.ts
@@ -1,8 +1,10 @@
 export type Attestation = {
   id: string;
+  index: number;
   creator: string;
   receiver: string;
   keyString: string;
+  val: string;
   valueString: string;
 };
 
@@ -11,13 +13,20 @@ export type GetAttestationDataType = {
 };
 
 export type GetAttestationParams = {
+  creator: string;
+  key?: string;
+  value?: string;
+};
+
+export type GetAttestationValueParams = {
+  creator: string;
   key: string;
-  value: string;
 };
 
 export type QueryParams = {
-  key: string;
-  value: string;
-  first?: number
-  skip?: number;
+  creator: string;
+  key?: string;
+  value?: string;
+  first?: number;
+  index?: number;
 };

--- a/group-generators/helpers/data-providers/index.ts
+++ b/group-generators/helpers/data-providers/index.ts
@@ -134,6 +134,10 @@ export const dataProvidersAPIEndpoints = {
       new AttestationStationProvider().getAttestations(_),
     getAttestationsCount: async (_: any) =>
       new AttestationStationProvider().getAttestationsCount(_),
+    getAttestationValues: async (_: any) =>
+      new AttestationStationProvider().getAttestationValues(_),
+    getAttestationValuesCount: async (_: any) =>
+      new AttestationStationProvider().getAttestationValuesCount(_),
   },
   DegenScoreProvider: {
     getBeaconOwnersWithScoreCount: async (_: any) =>


### PR DESCRIPTION
The previous implementation required that attestation matched specific key/value pairs.

This update allows to use the attestation values if these are numeric. Otherwise still counts as 1.
This allows for more control over the ATST data provider.