### PR TITLE
feat: add safe data provider

### DIFF
--- a/group-generators/helpers/data-providers/index.ts
+++ b/group-generators/helpers/data-providers/index.ts
@@ -32,6 +32,8 @@ import { PoapSubgraphProvider } from "./poap";
 import poapInterfaceSchema from "./poap/interface-schema.json";
 import { RestProvider } from "./rest-api";
 import restInterfaceSchema from "./rest-api/interface-schema.json";
+import { SafeProvider } from './safe';
+import safeInterfaceSchema from "./safe/interface-schema.json";
 import {
   SismoSubgraphProvider,
   SismoSubgraphBaseProvider,
@@ -75,6 +77,7 @@ export const dataProviders = {
   OtterSpaceSubgraphProvider,
   PoapSubgraphProvider,
   RestProvider,
+  SafeProvider,
   SismoSubgraphProvider,
   SismoSubgraphBaseProvider,
   Subgraph101Provider,
@@ -101,6 +104,7 @@ export const dataProvidersInterfacesSchemas: DataProviderInterface[] = [
   otterspaceInterfaceSchema,
   poapInterfaceSchema,
   restInterfaceSchema,
+  safeInterfaceSchema,
   snapshotInterfaceSchema,
   subgraph101InterfaceSchema,
   talentLayerProviderInterfaceSchema,
@@ -200,6 +204,10 @@ export const dataProvidersAPIEndpoints = {
   RestProvider: {
     getAccountsCountFromAPI: async (_: any) =>
       new RestProvider().getAccountsCountFromAPI(_),
+  },
+  SafeProvider: {
+    getSafeOwnersCount: async (_: any) =>
+      new SafeProvider().getSafeOwnersCount(_),
   },
   SnapshotProvider: {
     querySpaceVotersCount: async (_: any) =>

--- a/group-generators/helpers/data-providers/safe/index.ts
+++ b/group-generators/helpers/data-providers/safe/index.ts
@@ -1,0 +1,51 @@
+import axios from "axios";
+import { Safe, SafeAddress } from "./types";
+import { FetchedData } from "topics/group";
+
+export class SafeProvider {
+  url: string;
+
+  public constructor() {
+    this.url = "https://safe-transaction-mainnet.safe.global/api";
+  }
+
+  private async getSafe(endpoint: string): Promise<Safe> {
+    const { data: res } = await axios({
+      url: this.url + endpoint,
+      method: "get",
+    });
+    return res;
+  }
+
+  public async getSafeOwners({
+    safeAddress,
+  }: SafeAddress): Promise<FetchedData> {
+    const dataProfiles: FetchedData = {};
+    let ownersAddress: string[];
+    try {
+      const req: Safe = await this.getSafe(
+        "/v1/safes/" + safeAddress
+      );
+      ownersAddress = req.owners;
+    } catch (error) {
+      throw new Error("Error fetching total number of owners: " + error);
+    }
+
+    await Promise.all(ownersAddress).then((addresses) => {
+      addresses.forEach((address) => {
+        if (address != "") {
+          dataProfiles[address] = 1;
+        }
+      });
+    });
+
+    return dataProfiles;
+  }
+
+  public async getSafeOwnersCount({
+    safeAddress,
+  }: SafeAddress): Promise<number> {
+    const holders = await this.getSafeOwners({ safeAddress });
+    return Object.keys(holders).length;
+  }
+}

--- a/group-generators/helpers/data-providers/safe/interface-schema.json
+++ b/group-generators/helpers/data-providers/safe/interface-schema.json
@@ -1,0 +1,22 @@
+{
+  "name": "Safe",
+  "iconUrl": "",
+  "providerClassName": "SafeProvider",
+  "functions": [
+    {
+      "name": "Get owners of Safe",
+      "functionName": "getSafeOwners",
+      "countFunctionName": "getSafeOwnersCount",
+      "description": "Returns all owners of the Safe smart contract on Ethereum",
+      "args": [
+        {
+          "name": "safeAddress",
+          "argName": "safeAddress",
+          "type": "string",
+          "example": "0xFA9e2616f07C2C2E5f3Ee77B8aF5eA9AFED77278",
+          "description": "Address of the Safe smart contract on Ethereum"
+        }
+      ]
+    }
+  ]
+}

--- a/group-generators/helpers/data-providers/safe/types.ts
+++ b/group-generators/helpers/data-providers/safe/types.ts
@@ -1,0 +1,13 @@
+export type SafeAddress = { safeAddress: string };
+
+export type Safe = {
+    address: string,
+    nonce: number,
+    threshold: number,
+    owners: string[],
+    masterCopy: string,
+    modules: string[],
+    fallbackHandler: string,
+    guard: string,
+    version: string
+};


### PR DESCRIPTION
## Context
I missed [Safe](https://safe.global/) data provider so I can create new Groups based on owners of these multisigs. I saw their official [REST API](https://safe-transaction-mainnet.safe.global/) for Ethereum smart contract wallets and implemented it.

## Changes Made
I created a new folder in `group-generators/helpers/data-providers` named `safe` and inside it I created all the necessary files to create a new Data Provider.

Then I imported everything to `group-generators/helpers/data-providers/index.ts`.

## Benefits
People can now use this new data provider to get all owners of specific Safe smart contact on Ethereum. Users can now prove in privacy-preserving way that they own some [Safe wallet](https://safe.global/wallet) without revealing what address from the owners is their.

## Checklist
[x] I have tested my changes and confirmed that they work as expected
[x] I have updated the relevant documentation, including the Contributor Guide and the README
[x] I have added any necessary tests to ensure that my changes are protected from future regressions