### PR TITLE
Add EAS data provider

### DIFF
--- a/group-generators/helpers/data-providers/eas/index.ts
+++ b/group-generators/helpers/data-providers/eas/index.ts
@@ -17,7 +17,7 @@ export class EthereumAttestationServiceProvider {
     return dataProfiles;
   }
 
-  public async getAttestationRecipientCount(
+  public async getAttestationRecipientsCount(
     params: GetAttestationParams
   ): Promise<number> {
     const attestations = await this.getAttestationRecipients(params);
@@ -102,14 +102,18 @@ export class EthereumAttestationServiceProvider {
         const values = JSON.parse(i.decodedDataJson);
         const val = values.find((v: any) => {
           if (params.key && !params.value)
-            return v.name.toLowerCase() === params.key.toLowerCase();
+            return v.name.toString().toLowerCase() === params.key.toLowerCase();
 
           if (!params.key && params.value)
-            return v.value.value.toLowerCase() === params.value.toLowerCase();
+            return (
+              v.value.value.toString().toLowerCase() ===
+              params.value.toLowerCase()
+            );
 
           return (
-            v.name.toLowerCase() === params.key?.toLowerCase() &&
-            v.value.value.toLowerCase() === params.value?.toLowerCase()
+            v.name.toString().toLowerCase() === params.key?.toLowerCase() &&
+            v.value.value.toString().toLowerCase() ===
+              params.value?.toLowerCase()
           );
         });
 

--- a/group-generators/helpers/data-providers/eas/index.ts
+++ b/group-generators/helpers/data-providers/eas/index.ts
@@ -1,0 +1,111 @@
+import { GraphQLClient } from "graphql-request";
+import { GetAttestationParams, QueryParams } from "./types";
+import { FetchedData } from "topics/group";
+
+export const defaultLimit = 100;
+
+export class EthereumAttestationServiceProvider {
+  public async getAttestationRecipients(
+    params: GetAttestationParams
+  ): Promise<FetchedData> {
+    const dataProfiles: FetchedData = {};
+
+    for await (const item of this._getAttestations(params)) {
+      dataProfiles[item.recipient] = 1;
+    }
+
+    return dataProfiles;
+  }
+
+  public async getAttestationRecipientCount(
+    params: GetAttestationParams
+  ): Promise<number> {
+    const attestations = await this.getAttestationRecipients(params);
+    return Object.keys(attestations).length;
+  }
+
+  public async getAttestationValues(
+    params: GetAttestationParams
+  ): Promise<FetchedData> {
+    const dataProfiles: FetchedData = {};
+
+    for await (const item of this._getAttestations(params)) {
+      const value = isNaN(Number(item.value)) ? 1 : Number(item.value);
+      dataProfiles[item.recipient] = value;
+    }
+
+    return dataProfiles;
+  }
+
+  public async getAttestationValuesCount(
+    params: GetAttestationParams
+  ): Promise<number> {
+    const attestations = await this.getAttestationValues(params);
+    return Object.keys(attestations).length;
+  }
+
+  private async *_getAttestations(params: QueryParams) {
+    const baseUri = `https://${
+      params.network ? `${params.network}.` : ""
+    }easscan.org/graphql`;
+    const client = new GraphQLClient(baseUri);
+    let offset = 0;
+    let hasNext = true;
+
+    while (hasNext) {
+      const res = await client.request(`
+        {
+          attestations(take: ${defaultLimit} skip: ${offset} where: {
+            revoked: {
+              equals: false
+            }
+            attester: {
+              equals: "${params.attester}",
+              mode: insensitive
+            }
+            schemaId: {
+              equals: "${params.schema}",
+              mode: insensitive
+            }
+            }) {
+            id
+            attester
+            recipient
+            revoked
+            data
+            decodedDataJson
+            time
+            timeCreated
+            schema {
+              id
+              schema
+            }
+          }
+        }
+      `);
+
+      if (!params.key && !params.value) yield* res.attestations;
+
+      yield* res.attestations.filter((i: any) => {
+        const values = JSON.parse(i.decodedDataJson);
+        const val = values.find((v: any) => {
+          if (params.key && !params.value)
+            return v.name.toLowerCase() === params.key.toLowerCase();
+
+          if (!params.key && params.value)
+            return v.value.value.toLowerCase() === params.value.toLowerCase();
+
+          return (
+            v.name.toLowerCase() === params.key?.toLowerCase() &&
+            v.value.value.toLowerCase() === params.value?.toLowerCase()
+          );
+        });
+
+        return !!val;
+      });
+
+      offset += res.attestations.length;
+      hasNext = res.attestations.length === defaultLimit;
+    }
+  }
+}

--- a/group-generators/helpers/data-providers/eas/index.ts
+++ b/group-generators/helpers/data-providers/eas/index.ts
@@ -67,6 +67,18 @@ export class EthereumAttestationServiceProvider {
               equals: "${params.schema}",
               mode: insensitive
             }
+            OR: [
+              {
+                expirationTime: {
+                  gt: ${Math.floor(Date.now() / 1000)}
+                }   
+              }
+              {
+                expirationTime: {
+                  equals: 0
+                }   
+              }
+            ]
             }) {
             id
             attester

--- a/group-generators/helpers/data-providers/eas/index.ts
+++ b/group-generators/helpers/data-providers/eas/index.ts
@@ -1,10 +1,16 @@
-import { GraphQLClient } from "graphql-request";
 import { GetAttestationParams, QueryParams } from "./types";
+import { GraphQLProvider } from "@group-generators/helpers/data-providers/graphql";
 import { FetchedData } from "topics/group";
 
 export const defaultLimit = 100;
 
-export class EthereumAttestationServiceProvider {
+export class EthereumAttestationServiceProvider extends GraphQLProvider {
+  constructor() {
+    super({
+      url: "https://easscan.org/graphql",
+    });
+  }
+
   public async getAttestationRecipients(
     params: GetAttestationParams
   ): Promise<FetchedData> {
@@ -45,15 +51,17 @@ export class EthereumAttestationServiceProvider {
   }
 
   private async *_getAttestations(params: QueryParams) {
-    const baseUri = `https://${
-      params.network ? `${params.network}.` : ""
-    }easscan.org/graphql`;
-    const client = new GraphQLClient(baseUri);
+    if (params.network) {
+      this.graphQLClient.setEndpoint(
+        `https://${params.network}.easscan.org/graphql`
+      );
+    }
+
     let offset = 0;
     let hasNext = true;
 
     while (hasNext) {
-      const res = await client.request(`
+      const res = await this.graphQLClient.request(`
         {
           attestations(take: ${defaultLimit} skip: ${offset} where: {
             revoked: {

--- a/group-generators/helpers/data-providers/eas/interface-schema.json
+++ b/group-generators/helpers/data-providers/eas/interface-schema.json
@@ -6,7 +6,7 @@
     {
       "name": "Get recipients",
       "functionName": "getAttestationRecipients",
-      "countFunctionName": "getAttestationRecipients",
+      "countFunctionName": "getAttestationRecipientsCount",
       "description": "Returns all the recipients of a specific attestation",
       "args": [
         {
@@ -50,7 +50,7 @@
       "name": "Get attestation values",
       "functionName": "getAttestationValues",
       "countFunctionName": "getAttestationValuesCount",
-      "description": "Uses the values of the attestations if these are numeric. Otherwise counts as 1.",
+      "description": "Returns all the recipients of a specific attestation and associate the values of it to the corresponding recipients addresses if these are numeric. Otherwise counts as 1.",
       "args": [
 
         {

--- a/group-generators/helpers/data-providers/eas/interface-schema.json
+++ b/group-generators/helpers/data-providers/eas/interface-schema.json
@@ -1,0 +1,94 @@
+{
+  "name": "Ethereum Attestation Service",
+  "iconUrl": "",
+  "providerClassName": "EthereumAttestationServiceProvider",
+  "functions": [
+    {
+      "name": "Get recipients",
+      "functionName": "getAttestationRecipients",
+      "countFunctionName": "getAttestationRecipients",
+      "description": "Returns all the recipients of a specific attestation",
+      "args": [
+        {
+          "name": "network",
+          "argName": "network",
+          "type": "string",
+          "example": "arbitrum",
+          "description": "The network to query attestations. Currently supports: arbitrum, sepolia (or leave empty for mainnet)"
+        },
+        {
+          "name": "schema",
+          "argName": "schema",
+          "type": "string",
+          "example": "0x85500e806cf1e74844d51a20a6d893fe1ed6f6b0738b50e43d774827d08eca61",
+          "description": "The schema used for the attestation"
+        },
+        {
+          "name": "attester",
+          "argName": "attester",
+          "type": "string",
+          "example": "0x0fb166cDdF1387C5b63fFa25721299fD7b068f3f",
+          "description": "The creator of the attestation"
+        },
+        {
+          "name": "key",
+          "argName": "key",
+          "type": "string",
+          "example": "Gm",
+          "description": "The property of the schema that is being attested"
+        },
+        {
+          "name": "value",
+          "argName": "value",
+          "type": "string",
+          "example": "True",
+          "description": "The required value of the property that is being attested"
+        }
+      ]
+    },
+    {
+      "name": "Get attestation values",
+      "functionName": "getAttestationValues",
+      "countFunctionName": "getAttestationValuesCount",
+      "description": "Uses the values of the attestations if these are numeric. Otherwise counts as 1.",
+      "args": [
+
+        {
+          "name": "network",
+          "argName": "network",
+          "type": "string",
+          "example": "arbitrum",
+          "description": "The network to query attestations. Currently supports: arbitrum, sepolia (or leave empty for mainnet)"
+        },
+        {
+          "name": "schema",
+          "argName": "schema",
+          "type": "string",
+          "example": "0xcdf08a92668c6ddb8f574d0b0b03c9b8663869f924e81738009b044069a22617",
+          "description": "The schema used for the attestation"
+        },
+        {
+          "name": "attester",
+          "argName": "attester",
+          "type": "string",
+          "example": "0x0fb166cDdF1387C5b63fFa25721299fD7b068f3f",
+          "description": "The creator of the attestation"
+        },
+        {
+          "name": "key",
+          "argName": "key",
+          "type": "string",
+          "example": "Age",
+          "description": "The property of the schema that is being attested"
+        },
+        {
+          "name": "value",
+          "argName": "value",
+          "type": "string",
+          "example": "18",
+          "description": "The required value of the property that is being attested"
+        }
+      ]
+    }
+  ]
+}

--- a/group-generators/helpers/data-providers/eas/types.ts
+++ b/group-generators/helpers/data-providers/eas/types.ts
@@ -1,0 +1,28 @@
+export interface Attestation {
+  id: string;
+  attester: string;
+  recipient: string;
+  revoked: boolean;
+  decodedDataJson: string;
+  data: string;
+  key: string;
+  time: number;
+  timeCreated: number;
+}
+
+export interface GetAttestationResult {
+  attestations: Attestation[];
+}
+
+export interface GetAttestationParams {
+  network?: "arbitrum" | "sepolia";
+  schema: string;
+  attester: string;
+  key?: string;
+  value?: string;
+}
+
+export interface QueryParams extends GetAttestationParams {
+  take?: number;
+  skip?: number;
+}

--- a/group-generators/helpers/data-providers/index.ts
+++ b/group-generators/helpers/data-providers/index.ts
@@ -10,6 +10,8 @@ import { BigQueryProvider } from "./big-query/big-query";
 import { DegenScoreProvider } from "./degenscore";
 import degenScoreInterfaceSchema from "./degenscore/interface-schema.json";
 import { DuneProvider } from "./dune";
+import { EthereumAttestationServiceProvider } from "./eas";
+import ethereumAttestationServiceInterfaceSchema from "./eas/interface-schema.json";
 import { EnsProvider } from "./ens";
 import { EthLeaderboardProvider } from "./eth-leaderboard";
 import { FarcasterProvider } from "./farcaster";
@@ -71,6 +73,7 @@ export const dataProviders = {
   BigQueryProvider,
   DegenScoreProvider,
   DuneProvider,
+  EthereumAttestationServiceProvider,
   EnsProvider,
   EthLeaderboardProvider,
   FarcasterProvider,
@@ -106,6 +109,7 @@ export const dataProvidersInterfacesSchemas: DataProviderInterface[] = [
   attestationStationInterfaceSchema,
   ankrInterfaceSchema,
   degenScoreInterfaceSchema,
+  ethereumAttestationServiceInterfaceSchema,
   galxeInterfaceSchema,
   githubInterfaceSchema,
   gitPoapInterfaceSchema,
@@ -174,6 +178,16 @@ export const dataProvidersAPIEndpoints = {
   DegenScoreProvider: {
     getBeaconOwnersWithScoreCount: async (_: any) =>
       new DegenScoreProvider().getBeaconOwnersWithScoreCount(_),
+  },
+  EthereumAttestationServiceProvider: {
+    getAttestationRecipients: async (_: any) =>
+      new EthereumAttestationServiceProvider().getAttestationRecipients(_),
+    getAttestationRecipientCount: async (_: any) =>
+      new EthereumAttestationServiceProvider().getAttestationRecipientCount(_),
+    getAttestationValues: async (_: any) =>
+      new EthereumAttestationServiceProvider().getAttestationValues(_),
+    getAttestationValuesCount: async (_: any) =>
+      new EthereumAttestationServiceProvider().getAttestationValuesCount(_),
   },
   GithubProvider: {
     getRepositoriesContributorsCount: async (_: any) =>

--- a/group-generators/helpers/data-providers/index.ts
+++ b/group-generators/helpers/data-providers/index.ts
@@ -182,8 +182,8 @@ export const dataProvidersAPIEndpoints = {
   EthereumAttestationServiceProvider: {
     getAttestationRecipients: async (_: any) =>
       new EthereumAttestationServiceProvider().getAttestationRecipients(_),
-    getAttestationRecipientCount: async (_: any) =>
-      new EthereumAttestationServiceProvider().getAttestationRecipientCount(_),
+    getAttestationRecipientsCount: async (_: any) =>
+      new EthereumAttestationServiceProvider().getAttestationRecipientsCount(_),
     getAttestationValues: async (_: any) =>
       new EthereumAttestationServiceProvider().getAttestationValues(_),
     getAttestationValuesCount: async (_: any) =>


### PR DESCRIPTION
This PR adds Ethereum Attestation Service (EAS) as a data provider.
https://easscan.org/

It allows you to search for attestation at different networks (currently supports mainnet, arbitrum and sepolia) by
- schema + attester
- schema + attester + key
- schema + attester + key + value

Some test data..

1.
network: sepolia
schema: 0x35d34c24b7c192050f4e3f2f2d4ccd65a3bc2e38b42eafa3e91973efbb1570fc
attester: 0x8289432ACD5EB0214B1C2526A5EDB480Aa06A9ab

View on EAS explorer https://sepolia.easscan.org/attestations/forSchema/0x35d34c24b7c192050f4e3f2f2d4ccd65a3bc2e38b42eafa3e91973efbb1570fc

2.
network: arbitrum
schema: 0xe093d91b9358e839e71dece1c23c00ce4d3e04fab8c2c9e393543165cdcdd2c0
attester: 0xa9cc4b8C03e88483A02ae9E1975857bc06bcFe90
key: Project_contribution_uuid
value: 0x6d91615c65c0e8f861b0fbfce2d9897fb942293e341eda10c91a6912c4f32668

View on EAS explorer https://arbitrum.easscan.org/attestations/forSchema/0xe093d91b9358e839e71dece1c23c00ce4d3e04fab8c2c9e393543165cdcdd2c0
