### PR TITLE
Discourse data provider and group generator

### DIFF
--- a/group-generators/generators/dao-forum-users/index.ts
+++ b/group-generators/generators/dao-forum-users/index.ts
@@ -1,0 +1,34 @@
+
+import { dataProviders } from "@group-generators/helpers/data-providers";
+import { Tags, ValueType, GroupWithData } from "topics/group";
+import {
+  GenerationContext,
+  GenerationFrequency,
+  GroupGenerator,
+} from "topics/group-generator";
+
+const generator: GroupGenerator = {
+  generationFrequency: GenerationFrequency.Once,
+  
+  generate: async (context: GenerationContext): Promise<GroupWithData[]> => {
+  
+    const discourseProvider = new dataProviders.DiscourseProvider();
+    const gnosisForumUsers = await discourseProvider.getAllUsersFromAPI({
+      url: "https://forum.gnosis.io/"
+    });
+
+    return [
+      {
+        name: "gnosis-forum-users",
+        timestamp: context.timestamp,
+        description: "Discourse user: Gnosis Forum",
+        specs: "Anyone that is a Gnosis Forum user.",
+        data: gnosisForumUsers,
+        valueType: ValueType.Score,
+        tags: [Tags.Factory],
+      },
+    ];
+  },
+};
+
+export default generator;

--- a/group-generators/generators/index.ts
+++ b/group-generators/generators/index.ts
@@ -101,7 +101,8 @@ import cyber from "./cyber";
 import cyberconnect from "./cyberconnect";
 import cyberconnectAmbassador from "./cyberconnect-ambassador";
 import dale1075 from "./dale1075";
-import daoContributor from "./dao-contributor";
+import daoContributor from "./dao-contributor"
+import daoForumUsers from "./dao-forum-users";
 import davidZkBadge from "./david-zk-badge";
 import degenSwag from "./degen-swag";
 import degens from "./degens";
@@ -817,6 +818,7 @@ export const groupGenerators: GroupGeneratorsLibrary = {
   "gitcoin-presents": gitcoinPresents,
   "gitpoap-2023-sismo-contributor": gitpoap2023SismoContributor,
   "gm": gm,
+  "dao-forum-users": daoForumUsers,
   "goofy13": goofy13,
   "gotchi-french-army-x-sismo-live": gotchiFrenchArmyXSismoLive,
   "grail-member": grailMember,

--- a/group-generators/helpers/data-providers/discourse/index.ts
+++ b/group-generators/helpers/data-providers/discourse/index.ts
@@ -1,0 +1,66 @@
+import axios from "axios";
+import { ethers } from "ethers";
+import { ApiConfig } from "./types";
+import { FetchedData } from "topics/group";
+
+class DiscourseProvider {
+  public async getAllUsersFromAPI({ url }: ApiConfig): Promise<FetchedData> {
+    const usersData: FetchedData = {};
+
+    const firstPageUrl = "/directory_items.json?period=daily&order=days_visited"
+    let queryUrl = `${url}${firstPageUrl}`
+
+    while (url) {
+      const {pageUsersData, nextPageUrl} = await this.getAccountsFromAPI({ url: queryUrl });
+      if (pageUsersData.length === 0) break;
+
+      queryUrl = `${url}${nextPageUrl}`;
+      const pageAddressesArr = await pageUsersData.filter((user : any) => {
+        return user.user.name 
+        && user.user.name.length > 32
+        && ethers.utils.isAddress(user.user.name.substring(0, 42));
+      })
+      
+      pageAddressesArr.map((user : any) => usersData[user.user.name.substring(0, 42)] = 1)
+
+    }
+    return usersData;
+  }
+
+  
+
+ /**
+   * Use this method to query any rest api with the GET method
+   * @param options Used to pass url of the request.
+   * @returns The data of the api request which must be in FetchData type { [address: string]: number }
+   */
+  private async getAccountsFromAPI({ url }: ApiConfig): Promise<any> {
+    try {
+      const headers = {
+        "User-Agent": 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36',
+      };
+
+      const { data: responseData } = await axios({
+        url: url,
+        method: "get",
+        headers
+      });
+      return { pageUsersData: responseData.directory_items, nextPageUrl : responseData.meta.load_more_directory_items};
+    } catch (error) {
+      console.log(error);
+      throw new Error("Failed to fetch data...");
+    }
+  }
+
+   /**
+   * Use this method to query any rest api with the GET method and return the number of accounts
+   * @param options Used to pass url of the request.
+   * @returns The data of the api request which must be in FetchData type { [address: string]: number }
+   */
+    public async getAccountsCountFromAPI({ url }: ApiConfig): Promise<number> {
+      const accounts = await this.getAllUsersFromAPI({ url });
+      return Object.keys(accounts).length;
+    }
+}
+
+export { DiscourseProvider, ApiConfig };

--- a/group-generators/helpers/data-providers/discourse/types.ts
+++ b/group-generators/helpers/data-providers/discourse/types.ts
@@ -1,0 +1,15 @@
+import { AxiosRequestHeaders, Method } from "axios";
+
+export type ApiConfig = {
+  // `url` is the api URL that will be used for the request
+  url: string;
+
+  // `method` is the request method to be used when making the request
+  method?: Method;
+
+  // `headers` is the headers of your axios request, where you can add your authentification token
+  headers?: AxiosRequestHeaders;
+
+  // `data` is the data to be sent as the request body
+  data?: object;
+};

--- a/group-generators/helpers/data-providers/index.ts
+++ b/group-generators/helpers/data-providers/index.ts
@@ -9,6 +9,7 @@ import attestationStationInterfaceSchema from "./atst/interface-schema.json";
 import { BigQueryProvider } from "./big-query/big-query";
 import { DegenScoreProvider } from "./degenscore";
 import degenScoreInterfaceSchema from "./degenscore/interface-schema.json";
+import { DiscourseProvider } from "./discourse"
 import { DuneProvider } from "./dune";
 import { EthereumAttestationServiceProvider } from "./eas";
 import ethereumAttestationServiceInterfaceSchema from "./eas/interface-schema.json";
@@ -74,6 +75,7 @@ export const dataProviders = {
   AnkrProvider,
   BigQueryProvider,
   DegenScoreProvider,
+  DiscourseProvider,
   DuneProvider,
   EthereumAttestationServiceProvider,
   EnsProvider,
@@ -183,6 +185,10 @@ export const dataProvidersAPIEndpoints = {
   DegenScoreProvider: {
     getBeaconOwnersWithScoreCount: async (_: any) =>
       new DegenScoreProvider().getBeaconOwnersWithScoreCount(_),
+  },
+  DiscourseProvider: {
+    getAllUsersFromAPI: async (_: any) => 
+      new DiscourseProvider().getAllUsersFromAPI(_),
   },
   EnsSubdomainProvider: {
     getEnsSubdomainsCount: async (_: any) => {


### PR DESCRIPTION
For EthGlobal Lisbon hackathon we want to fetch a list of Discourse users as a group generator.

Future work:
- Users should post signature instead of an address in their Discourse profile
- Data should be located in user fields instead of in the "name" field

The reasons we opted for these are time constraints, as discussed with @leosayous21 . We intend to develop further but project submission is in like 12h 🔥 