### PR TITLE
fix: resolvers (case sensibility issue)

### DIFF
--- a/src/topics/resolver/ens-resolver.ts
+++ b/src/topics/resolver/ens-resolver.ts
@@ -27,7 +27,10 @@ export class EnsResolver extends GraphQLProvider implements IResolver {
     resolvedAccountsRaw: FetchedData;
     resolvedAccounts: FetchedData;
   }> {
-    const unresolvedAccountsArray = Object.entries(accounts);
+    const unresolvedAccountsArray = Object.entries(accounts).map(
+      ([account, value]) =>
+        [account.toLowerCase(), value] as [string, BigNumberish]
+    );
 
     const resolvedAccountsArrays = await withConcurrency(
       unresolvedAccountsArray,

--- a/src/topics/resolver/github-resolver.ts
+++ b/src/topics/resolver/github-resolver.ts
@@ -98,7 +98,8 @@ export class GithubResolver implements IResolver {
 
     if (res !== undefined) {
       const account = accountsWithoutType.find(
-        ([account]) => account === username[0]
+        ([account]) =>
+          account.toLocaleLowerCase() === res.data.login.toLowerCase()
       );
       if (account) {
         const resolvedAccount = resolveAccount("1001", res.data.id);

--- a/src/topics/resolver/github-resolver.ts
+++ b/src/topics/resolver/github-resolver.ts
@@ -98,8 +98,7 @@ export class GithubResolver implements IResolver {
 
     if (res !== undefined) {
       const account = accountsWithoutType.find(
-        ([account]) =>
-          account.toLocaleLowerCase() === res.data.login.toLowerCase()
+        ([account]) => account.toLowerCase() === res.data.login.toLowerCase()
       );
       if (account) {
         const resolvedAccount = resolveAccount("1001", res.data.id);

--- a/src/topics/resolver/lens-resolver.ts
+++ b/src/topics/resolver/lens-resolver.ts
@@ -22,7 +22,10 @@ export class LensResolver extends GraphQLProvider implements IResolver {
     resolvedAccountsRaw: FetchedData;
     resolvedAccounts: FetchedData;
   }> {
-    const unresolvedAccountsArray = Object.entries(accounts);
+    const unresolvedAccountsArray = Object.entries(accounts).map(
+      ([account, value]) =>
+        [account.toLowerCase(), value] as [string, BigNumberish]
+    );
 
     const resolvedAccountsArrays = await withConcurrency(
       unresolvedAccountsArray,

--- a/src/topics/resolver/telegram-resolver.ts
+++ b/src/topics/resolver/telegram-resolver.ts
@@ -147,7 +147,24 @@ export class TelegramResolver implements IResolver {
         );
       }
     });
-
+    // if some accounts haven't been resolved
+    if (
+      Object.keys(resolvedAccounts).length < Object.keys(accounts).length
+    ) {
+      const accountsNotResolved = accounts
+        .filter(
+          ([account]) =>
+            !Object.entries(resolvedAccounts).find(
+              ([acc]) => acc === account
+            )
+        )
+        .map(([account]) => account);
+      handleResolvingErrors(
+        `Error on these Telegram usernames: ${accountsNotResolved.join(
+          ", "
+        )}. Are they existing Telegram usernames?`
+      );
+    }
     return [updatedAccounts, resolvedAccounts];
   };
 

--- a/src/topics/resolver/telegram-resolver.ts
+++ b/src/topics/resolver/telegram-resolver.ts
@@ -134,7 +134,7 @@ export class TelegramResolver implements IResolver {
       try {
         const user = peer.users[0] as Api.User;
         const account = accountsWithoutType.find(
-          ([account]) => account === user.username
+          ([account]) => account.toLowerCase() === user.username?.toLowerCase()
         );
         if (account) {
           resolvedAccounts[resolveAccount("1003", user.id.toString())] =

--- a/src/topics/resolver/twitter-resolver.ts
+++ b/src/topics/resolver/twitter-resolver.ts
@@ -103,6 +103,24 @@ export class TwitterResolver implements IResolver {
             updatedAccounts[prefix + ":" + user.username] = account[1];
           }
         });
+        // if some accounts haven't been resolved
+        if (
+          Object.keys(resolvedAccounts).length < Object.keys(accounts).length
+        ) {
+          const accountsNotResolved = accounts
+            .filter(
+              ([account]) =>
+                !Object.entries(resolvedAccounts).find(
+                  ([acc]) => acc === account
+                )
+            )
+            .map(([account]) => account);
+          handleResolvingErrors(
+            `Error on these Twitter usernames: ${accountsNotResolved.join(
+              ", "
+            )}. Are they existing Twitter usernames?`
+          );
+        }
       }
       if (res.data.errors) {
         res.data.errors.forEach((error: any) => {

--- a/src/topics/resolver/twitter-resolver.ts
+++ b/src/topics/resolver/twitter-resolver.ts
@@ -96,7 +96,7 @@ export class TwitterResolver implements IResolver {
       if (res.data.data) {
         res.data.data.forEach((user: any) => {
           const account = accountsWithoutType.find(
-            ([account]) => account === user.username
+            ([account]) => account.toLowerCase() === user.username.toLowerCase()
           );
           if (account) {
             resolvedAccounts[resolveAccount("1002", user.id)] = account[1];


### PR DESCRIPTION
ENS & Lens: are case sensitive and it only accept characters in a name, so now we put the account we want to resolve in the lower case at the very beginning of the resolve process.

Twitter, Telegram, GitHub: are also case sensitives but we can have usernames with upper or lower cases. In order to get the value associated with an account, we need to put names in lower case when filter the array of accounts (in case we out 0xmarTingbZ instead of 0xMartinGbz).