### PR TITLE
fix: increase gas limit for registering root on chain

### DIFF
--- a/badges-metadata/base/hydra/infrastructure/on-chain-roots-registry.ts
+++ b/badges-metadata/base/hydra/infrastructure/on-chain-roots-registry.ts
@@ -54,10 +54,10 @@ export class OnChainRootsRegistry implements IRootsRegistry {
     const tx = this.attesterAddress ? await contract.registerRootForAttester(
       this.attesterAddress,
       root,
-      { gasLimit: 100000 }
+      { gasLimit: 300000 }
     ) : await contract.registerRoot(
       root,
-      { gasLimit: 100000 }
+      { gasLimit: 300000 }
     );
     await tx.wait();
     return tx.hash;
@@ -68,10 +68,10 @@ export class OnChainRootsRegistry implements IRootsRegistry {
     const tx = this.attesterAddress ? await contract.unregisterRootForAttester(
       this.attesterAddress,
       root,
-      { gasLimit: 100000 }
+      { gasLimit: 300000 }
     ) : await contract.unregisterRoot(
       root,
-      { gasLimit: 100000 }
+      { gasLimit: 300000 }
     ) ;
     await tx.wait();
     return tx.hash;


### PR DESCRIPTION
Increase gas limit for registering root on-chain. A lower limit was blocking for the arbitrum one chain