### PR TITLE
feat: new Lens BigQuery provider

### DIFF
--- a/group-generators/generators/0xlegion-lens-follower/index.ts
+++ b/group-generators/generators/0xlegion-lens-follower/index.ts
@@ -26,28 +26,23 @@ const generator: GroupGenerator = {
     // const lensProviderData0 = await LensProviderBigQuery.getFollowers({
     //   profileId: "MartinGbz"
     // });
-    // "0x4801eb5a2a6e2d04f019098364878c70a05158f1"
-    // 0x4801eB5a2A6E2D04F019098364878c70a05158F1
-    // 0x4801EB5A2A6E2D04F019098364878C70A05158F1
-
+    // // "0x4801eb5a2a6e2d04f019098364878c70a05158f1"
+    // // 0x4801eB5a2A6E2D04F019098364878c70a05158F1
+    // // 0x4801EB5A2A6E2D04F019098364878C70A05158F1
     // const count = await LensProviderBigQuery.getFollowersCount({
     //   profileId: "MartinGbz"
     // });
 
-    // console.log(count);
-
-    const lensProviderData0 = await LensProviderBigQuery.getPublicationCollectors({
-      publicationId: "0x01c960-0x10"
-    });
-    
-    const count = await LensProviderBigQuery.getPublicationCollectorsCount({
-      publicationId: "0x01c960-0x10"
-    });
+    // const lensProviderData0 = await LensProviderBigQuery.getPublicationCollectors({
+    //   publicationId: "0x01c960-0x10"
+    // });
+    // const count = await LensProviderBigQuery.getPublicationCollectorsCount({
+    //   publicationId: "0x01c960-0x10"
+    // });
     
     // const lensProviderData0 = await LensProviderBigQuery.getPublicationMirrorers({
     //   publicationId: "0x01c960-0x10"
     // });
-
     // const count = await LensProviderBigQuery.getPublicationMirrorersCount({
     //   publicationId: "0x01c960-0x10"
     // });
@@ -56,7 +51,6 @@ const generator: GroupGenerator = {
     //   publicationId: "0x10a6-0x29-DA-1dc746f6",
     //   reaction: "UPVOTE"
     // });
-
     // const count = await LensProviderBigQuery.getPublicationReactorsCount({
     //   publicationId: "0x10a6-0x29-DA-1dc746f6",
     //   reaction: "UPVOTE"
@@ -65,24 +59,16 @@ const generator: GroupGenerator = {
     // const lensProviderData0 = await LensProviderBigQuery.getPublicationCommenters({
     //   publicationId: "0x01-0x01e3"
     // });
-
     // const count = await LensProviderBigQuery.getPublicationCommentersCount({
     //   publicationId: "0x01-0x01e3"
     // });
 
-    // const lensProviderData0 = await LensProviderBigQuery.getHashtagMentioners({
-    //   hashtag: "#DeFi"
-    // });
-
-    // const count = await LensProviderBigQuery.getHashtagMentionersCount({
-    //   hashtag: "#DeFi"
-    // });
-
-    // const lensProvider = new dataProviders.LensProvider();
-
-    // const lensProviderData0 = await lensProvider.getFollowers({
-    //   profileId: "thisisatestinthefactory.eth"
-    // });
+    const lensProviderData0 = await LensProviderBigQuery.getHashtagMentioners({
+      hashtag: "#DeFi"
+    });
+    const count = await LensProviderBigQuery.getHashtagMentionersCount({
+      hashtag: "#DeFi"
+    });
 
     console.log("lensProviderData0", lensProviderData0);
 

--- a/group-generators/generators/0xlegion-lens-follower/index.ts
+++ b/group-generators/generators/0xlegion-lens-follower/index.ts
@@ -15,64 +15,11 @@ const generator: GroupGenerator = {
   
   generate: async (context: GenerationContext): Promise<GroupWithData[]> => {
   
-    // const lensProvider = new dataProviders.LensProvider();
+    const lensProvider = new dataProviders.LensProvider();
     
-    // const lensProviderData0 = await lensProvider.getFollowers({
-    //   profileId: "0xlegion.lens"
-    // });
-
-    const LensBigQueryProvider = new dataProviders.LensBigQueryProvider();
-
-    // const lensProviderData0 = await LensBigQueryProvider.getFollowers({
-    //   profileId: "MartinGbz"
-    // });
-    // // "0x4801eb5a2a6e2d04f019098364878c70a05158f1"
-    // // 0x4801eB5a2A6E2D04F019098364878c70a05158F1
-    // // 0x4801EB5A2A6E2D04F019098364878C70A05158F1
-    // const count = await LensBigQueryProvider.getFollowersCount({
-    //   profileId: "MartinGbz"
-    // });
-
-    // const lensProviderData0 = await LensBigQueryProvider.getPublicationCollectors({
-    //   publicationId: "0x01c960-0x10"
-    // });
-    // const count = await LensBigQueryProvider.getPublicationCollectorsCount({
-    //   publicationId: "0x01c960-0x10"
-    // });
-    
-    // const lensProviderData0 = await LensBigQueryProvider.getPublicationMirrorers({
-    //   publicationId: "0x01c960-0x10"
-    // });
-    // const count = await LensBigQueryProvider.getPublicationMirrorersCount({
-    //   publicationId: "0x01c960-0x10"
-    // });
-
-    // const lensProviderData0 = await LensBigQueryProvider.getPublicationCommenters({
-    //   publicationId: "0x01-0x01e3"
-    // });
-    // const count = await LensBigQueryProvider.getPublicationCommentersCount({
-    //   publicationId: "0x01-0x01e3"
-    // });
-
-    // const lensProviderData0 = await LensBigQueryProvider.getPublicationReactors({
-    //   publicationId: "0x10a6-0x29-DA-1dc746f6",
-    //   reaction: "UPVOTE"
-    // });
-    // const count = await LensBigQueryProvider.getPublicationReactorsCount({
-    //   publicationId: "0x10a6-0x29-DA-1dc746f6",
-    //   reaction: "UPVOTE"
-    // });
-
-    const lensProviderData0 = await LensBigQueryProvider.getHashtagMentioners({
-      hashtag: "#DeFi"
+    const lensProviderData0 = await lensProvider.getFollowers({
+      profileId: "0xlegion.lens"
     });
-    const count = await LensBigQueryProvider.getHashtagMentionersCount({
-      hashtag: "#DeFi"
-    });
-
-    console.log("lensProviderData0", lensProviderData0);
-
-    console.log("count", count);
 
     return [
       {

--- a/group-generators/generators/0xlegion-lens-follower/index.ts
+++ b/group-generators/generators/0xlegion-lens-follower/index.ts
@@ -21,52 +21,52 @@ const generator: GroupGenerator = {
     //   profileId: "0xlegion.lens"
     // });
 
-    const LensProviderBigQuery = new dataProviders.LensProviderBigQuery();
+    const LensBigQueryProvider = new dataProviders.LensBigQueryProvider();
 
-    // const lensProviderData0 = await LensProviderBigQuery.getFollowers({
+    // const lensProviderData0 = await LensBigQueryProvider.getFollowers({
     //   profileId: "MartinGbz"
     // });
     // // "0x4801eb5a2a6e2d04f019098364878c70a05158f1"
     // // 0x4801eB5a2A6E2D04F019098364878c70a05158F1
     // // 0x4801EB5A2A6E2D04F019098364878C70A05158F1
-    // const count = await LensProviderBigQuery.getFollowersCount({
+    // const count = await LensBigQueryProvider.getFollowersCount({
     //   profileId: "MartinGbz"
     // });
 
-    // const lensProviderData0 = await LensProviderBigQuery.getPublicationCollectors({
+    // const lensProviderData0 = await LensBigQueryProvider.getPublicationCollectors({
     //   publicationId: "0x01c960-0x10"
     // });
-    // const count = await LensProviderBigQuery.getPublicationCollectorsCount({
+    // const count = await LensBigQueryProvider.getPublicationCollectorsCount({
     //   publicationId: "0x01c960-0x10"
     // });
     
-    // const lensProviderData0 = await LensProviderBigQuery.getPublicationMirrorers({
+    // const lensProviderData0 = await LensBigQueryProvider.getPublicationMirrorers({
     //   publicationId: "0x01c960-0x10"
     // });
-    // const count = await LensProviderBigQuery.getPublicationMirrorersCount({
+    // const count = await LensBigQueryProvider.getPublicationMirrorersCount({
     //   publicationId: "0x01c960-0x10"
     // });
 
-    // const lensProviderData0 = await LensProviderBigQuery.getPublicationReactors({
-    //   publicationId: "0x10a6-0x29-DA-1dc746f6",
-    //   reaction: "UPVOTE"
-    // });
-    // const count = await LensProviderBigQuery.getPublicationReactorsCount({
-    //   publicationId: "0x10a6-0x29-DA-1dc746f6",
-    //   reaction: "UPVOTE"
-    // });
-
-    // const lensProviderData0 = await LensProviderBigQuery.getPublicationCommenters({
+    // const lensProviderData0 = await LensBigQueryProvider.getPublicationCommenters({
     //   publicationId: "0x01-0x01e3"
     // });
-    // const count = await LensProviderBigQuery.getPublicationCommentersCount({
+    // const count = await LensBigQueryProvider.getPublicationCommentersCount({
     //   publicationId: "0x01-0x01e3"
     // });
 
-    const lensProviderData0 = await LensProviderBigQuery.getHashtagMentioners({
+    // const lensProviderData0 = await LensBigQueryProvider.getPublicationReactors({
+    //   publicationId: "0x10a6-0x29-DA-1dc746f6",
+    //   reaction: "UPVOTE"
+    // });
+    // const count = await LensBigQueryProvider.getPublicationReactorsCount({
+    //   publicationId: "0x10a6-0x29-DA-1dc746f6",
+    //   reaction: "UPVOTE"
+    // });
+
+    const lensProviderData0 = await LensBigQueryProvider.getHashtagMentioners({
       hashtag: "#DeFi"
     });
-    const count = await LensProviderBigQuery.getHashtagMentionersCount({
+    const count = await LensBigQueryProvider.getHashtagMentionersCount({
       hashtag: "#DeFi"
     });
 

--- a/group-generators/generators/0xlegion-lens-follower/index.ts
+++ b/group-generators/generators/0xlegion-lens-follower/index.ts
@@ -15,11 +15,78 @@ const generator: GroupGenerator = {
   
   generate: async (context: GenerationContext): Promise<GroupWithData[]> => {
   
-    const lensProvider = new dataProviders.LensProvider();
+    // const lensProvider = new dataProviders.LensProvider();
     
-    const lensProviderData0 = await lensProvider.getFollowers({
-      profileId: "0xlegion.lens"
+    // const lensProviderData0 = await lensProvider.getFollowers({
+    //   profileId: "0xlegion.lens"
+    // });
+
+    const LensProviderBigQuery = new dataProviders.LensProviderBigQuery();
+
+    // const lensProviderData0 = await LensProviderBigQuery.getFollowers({
+    //   profileId: "MartinGbz"
+    // });
+    // "0x4801eb5a2a6e2d04f019098364878c70a05158f1"
+    // 0x4801eB5a2A6E2D04F019098364878c70a05158F1
+    // 0x4801EB5A2A6E2D04F019098364878C70A05158F1
+
+    // const count = await LensProviderBigQuery.getFollowersCount({
+    //   profileId: "MartinGbz"
+    // });
+
+    // console.log(count);
+
+    const lensProviderData0 = await LensProviderBigQuery.getPublicationCollectors({
+      publicationId: "0x01c960-0x10"
     });
+    
+    const count = await LensProviderBigQuery.getPublicationCollectorsCount({
+      publicationId: "0x01c960-0x10"
+    });
+    
+    // const lensProviderData0 = await LensProviderBigQuery.getPublicationMirrorers({
+    //   publicationId: "0x01c960-0x10"
+    // });
+
+    // const count = await LensProviderBigQuery.getPublicationMirrorersCount({
+    //   publicationId: "0x01c960-0x10"
+    // });
+
+    // const lensProviderData0 = await LensProviderBigQuery.getPublicationReactors({
+    //   publicationId: "0x10a6-0x29-DA-1dc746f6",
+    //   reaction: "UPVOTE"
+    // });
+
+    // const count = await LensProviderBigQuery.getPublicationReactorsCount({
+    //   publicationId: "0x10a6-0x29-DA-1dc746f6",
+    //   reaction: "UPVOTE"
+    // });
+
+    // const lensProviderData0 = await LensProviderBigQuery.getPublicationCommenters({
+    //   publicationId: "0x01-0x01e3"
+    // });
+
+    // const count = await LensProviderBigQuery.getPublicationCommentersCount({
+    //   publicationId: "0x01-0x01e3"
+    // });
+
+    // const lensProviderData0 = await LensProviderBigQuery.getHashtagMentioners({
+    //   hashtag: "#DeFi"
+    // });
+
+    // const count = await LensProviderBigQuery.getHashtagMentionersCount({
+    //   hashtag: "#DeFi"
+    // });
+
+    // const lensProvider = new dataProviders.LensProvider();
+
+    // const lensProviderData0 = await lensProvider.getFollowers({
+    //   profileId: "thisisatestinthefactory.eth"
+    // });
+
+    console.log("lensProviderData0", lensProviderData0);
+
+    console.log("count", count);
 
     return [
       {

--- a/group-generators/generators/ethereum-balances/index.ts
+++ b/group-generators/generators/ethereum-balances/index.ts
@@ -27,7 +27,7 @@ const generator: GroupGenerator = {
         `;
 
       const richUsers = dataOperators.Map(
-        await bigQueryProvider.fetch(query),
+        await bigQueryProvider.fetchAccounts(query),
         1
       );
 

--- a/group-generators/generators/ethereum-most-transactions/index.ts
+++ b/group-generators/generators/ethereum-most-transactions/index.ts
@@ -47,7 +47,7 @@ const generator: GroupGenerator = {
       // and suit a particular usecase
 
       const mostTransactionsUsers = dataOperators.Map(
-        await bigQueryProvider.fetch(query),
+        await bigQueryProvider.fetchAccounts(query),
         1
       );
 

--- a/group-generators/generators/stani-lens-followers/index.ts
+++ b/group-generators/generators/stani-lens-followers/index.ts
@@ -15,7 +15,7 @@ const generator: GroupGenerator = {
   
   generate: async (context: GenerationContext): Promise<GroupWithData[]> => {
   
-    const lensProvider = new dataProviders.LensProviderBigQuery();
+    const lensProvider = new dataProviders.LensBigQueryProvider();
     
     const lensProviderData0 = await lensProvider.getFollowers({
       profileId: "stani.lens"

--- a/group-generators/generators/stani-lens-followers/index.ts
+++ b/group-generators/generators/stani-lens-followers/index.ts
@@ -11,11 +11,11 @@ import {
 
 const generator: GroupGenerator = {
   
-  generationFrequency: GenerationFrequency.Once,
+  generationFrequency: GenerationFrequency.Daily,
   
   generate: async (context: GenerationContext): Promise<GroupWithData[]> => {
   
-    const lensProvider = new dataProviders.LensProvider();
+    const lensProvider = new dataProviders.LensProviderBigQuery();
     
     const lensProviderData0 = await lensProvider.getFollowers({
       profileId: "stani.lens"

--- a/group-generators/helpers/data-providers/big-query/big-query.ts
+++ b/group-generators/helpers/data-providers/big-query/big-query.ts
@@ -74,14 +74,22 @@ export class BigQueryProvider {
     return accounts;
   }
 
-  public async fetchCount(query: string): Promise<number> {
+  public async fetch(query: string): Promise<QueryRowsResponse> {
     const bigqueryClient = await this.authenticate();
 
     console.time("BigQuery request time");
     const response = await bigqueryClient.query(query)
     console.timeEnd("BigQuery request time");
 
-    console.log(response);
+    return response;
+  }
+
+  public async fetchCount(query: string): Promise<number> {
+    const bigqueryClient = await this.authenticate();
+
+    console.time("BigQuery request time");
+    const response = await bigqueryClient.query(query)
+    console.timeEnd("BigQuery request time");
 
     const count = response[0][0]["f0_"];
     return count;

--- a/group-generators/helpers/data-providers/big-query/big-query.ts
+++ b/group-generators/helpers/data-providers/big-query/big-query.ts
@@ -44,7 +44,7 @@ export class BigQueryProvider {
     });
   }
 
-  public async fetch(query: string) {
+  public async fetchAccounts(query: string) {
     const bigqueryClient = await this.authenticate();
 
     const accounts: { [address: string]: BigNumberish } = {};
@@ -80,6 +80,8 @@ export class BigQueryProvider {
     console.time("BigQuery request time");
     const response = await bigqueryClient.query(query)
     console.timeEnd("BigQuery request time");
+
+    console.log(response);
 
     const count = response[0][0]["f0_"];
     return count;
@@ -234,7 +236,7 @@ export class BigQueryProvider {
         where nb_transaction > ${minNumberOfTransactions}
         order by address 
         `;
-    return await this.fetch(query);
+    return await this.fetchAccounts(query);
   }
 
   public async getEvents<T>({

--- a/group-generators/helpers/data-providers/big-query/big-query.ts
+++ b/group-generators/helpers/data-providers/big-query/big-query.ts
@@ -44,6 +44,16 @@ export class BigQueryProvider {
     });
   }
 
+  public async fetch(query: string): Promise<QueryRowsResponse> {
+    const bigqueryClient = await this.authenticate();
+
+    console.time("BigQuery request time");
+    const response = await bigqueryClient.query(query)
+    console.timeEnd("BigQuery request time");
+
+    return response;
+  }
+
   public async fetchAccounts(query: string) {
     const bigqueryClient = await this.authenticate();
 
@@ -72,16 +82,6 @@ export class BigQueryProvider {
     });
     console.timeEnd("BigQuery request time");
     return accounts;
-  }
-
-  public async fetch(query: string): Promise<QueryRowsResponse> {
-    const bigqueryClient = await this.authenticate();
-
-    console.time("BigQuery request time");
-    const response = await bigqueryClient.query(query)
-    console.timeEnd("BigQuery request time");
-
-    return response;
   }
 
   public async fetchCount(query: string): Promise<number> {

--- a/group-generators/helpers/data-providers/big-query/big-query.ts
+++ b/group-generators/helpers/data-providers/big-query/big-query.ts
@@ -74,6 +74,17 @@ export class BigQueryProvider {
     return accounts;
   }
 
+  public async fetchCount(query: string): Promise<number> {
+    const bigqueryClient = await this.authenticate();
+
+    console.time("BigQuery request time");
+    const response = await bigqueryClient.query(query)
+    console.timeEnd("BigQuery request time");
+
+    const count = response[0][0]["f0_"];
+    return count;
+  }
+
   public async getNftHolders({
     contractAddress,
     options,

--- a/group-generators/helpers/data-providers/index.ts
+++ b/group-generators/helpers/data-providers/index.ts
@@ -31,7 +31,7 @@ import HiveInterfaceSchema from "./hive/interface-schema.json";
 import { JsonRpcProvider } from "./json-rpc";
 import { LensProvider } from "./lens";
 import { LensProviderBigQuery } from "./lens-bigquery";
-import lensInterfaceSchema from "./lens/interface-schema.json";
+import lensBigQueryInterfaceSchema from "./lens-bigquery/interface-schema.json";
 import { MirrorXyzSubgraphProvider } from "./mirrorxyz";
 import mirrorxyzInterfaceSchema from "./mirrorxyz/interface-schema.json";
 import { OtterSpaceSubgraphProvider } from "./otterspace";
@@ -121,7 +121,7 @@ export const dataProvidersInterfacesSchemas: DataProviderInterface[] = [
   gitPoapInterfaceSchema,
   guildInterfaceSchema,
   HiveInterfaceSchema,
-  lensInterfaceSchema,
+  lensBigQueryInterfaceSchema,
   mirrorxyzInterfaceSchema,
   otterspaceInterfaceSchema,
   poapInterfaceSchema,
@@ -214,13 +214,21 @@ export const dataProvidersAPIEndpoints = {
     getInfluencersFromClusterWithMinimumFollowersCount: async (_: any) =>
       new HiveProvider().getInfluencersFromClusterWithMinimumFollowersCount(_),
   },
-  LensProvider: {
+  LensProviderBigQuery: {
     getFollowersCount: async (_: any) =>
-      new LensProvider().getFollowersCount(_),
+      new LensProviderBigQuery().getFollowersCount(_),
     getPublicationCollectorsCount: async (_: any) =>
-      new LensProvider().getPublicationCollectorsCount(_),
-    getPublicationMirrorsCount: async (_: any) =>
-      new LensProvider().getPublicationMirrorsCount(_),
+      new LensProviderBigQuery().getPublicationCollectorsCount(_),
+    getPublicationMirrorersCount: async (_: any) =>
+      new LensProviderBigQuery().getPublicationMirrorersCount(_),
+    getPublicationCommentersCount: async (_: any) =>
+      new LensProviderBigQuery().getPublicationCommentersCount(_),
+    getPublicationReactorsCount: async (_: any) =>
+      new LensProviderBigQuery().getPublicationReactorsCount(_),
+    getHashtagMentionersCount: async (_: any) =>
+      new LensProviderBigQuery().getHashtagMentionersCount(_),
+    getProfilesRankCount: async (_: any) =>
+      new LensProviderBigQuery().getProfilesRankingCount(_),
   },
   MirrorXyzSubgraphProvider: {
     getPostCollectorsCount: async (_: any) =>

--- a/group-generators/helpers/data-providers/index.ts
+++ b/group-generators/helpers/data-providers/index.ts
@@ -30,7 +30,7 @@ import { HiveProvider } from "./hive";
 import HiveInterfaceSchema from "./hive/interface-schema.json";
 import { JsonRpcProvider } from "./json-rpc";
 import { LensProvider } from "./lens";
-import { LensProviderBigQuery } from "./lens-bigquery";
+import { LensBigQueryProvider } from "./lens-bigquery";
 import lensBigQueryInterfaceSchema from "./lens-bigquery/interface-schema.json";
 import { MirrorXyzSubgraphProvider } from "./mirrorxyz";
 import mirrorxyzInterfaceSchema from "./mirrorxyz/interface-schema.json";
@@ -90,7 +90,7 @@ export const dataProviders = {
   HiveProvider,
   JsonRpcProvider,
   LensProvider,
-  LensProviderBigQuery,
+  LensBigQueryProvider,
   MirrorXyzSubgraphProvider,
   OtterSpaceSubgraphProvider,
   PoapSubgraphProvider,
@@ -214,19 +214,19 @@ export const dataProvidersAPIEndpoints = {
     getInfluencersFromClusterWithMinimumFollowersCount: async (_: any) =>
       new HiveProvider().getInfluencersFromClusterWithMinimumFollowersCount(_),
   },
-  LensProviderBigQuery: {
+  LensBigQueryProvider: {
     getFollowersCount: async (_: any) =>
-      new LensProviderBigQuery().getFollowersCount(_),
+      new LensBigQueryProvider().getFollowersCount(_),
     getPublicationCollectorsCount: async (_: any) =>
-      new LensProviderBigQuery().getPublicationCollectorsCount(_),
+      new LensBigQueryProvider().getPublicationCollectorsCount(_),
     getPublicationMirrorersCount: async (_: any) =>
-      new LensProviderBigQuery().getPublicationMirrorersCount(_),
+      new LensBigQueryProvider().getPublicationMirrorersCount(_),
     getPublicationCommentersCount: async (_: any) =>
-      new LensProviderBigQuery().getPublicationCommentersCount(_),
+      new LensBigQueryProvider().getPublicationCommentersCount(_),
     getPublicationReactorsCount: async (_: any) =>
-      new LensProviderBigQuery().getPublicationReactorsCount(_),
+      new LensBigQueryProvider().getPublicationReactorsCount(_),
     getHashtagMentionersCount: async (_: any) =>
-      new LensProviderBigQuery().getHashtagMentionersCount(_),
+      new LensBigQueryProvider().getHashtagMentionersCount(_),
   },
   MirrorXyzSubgraphProvider: {
     getPostCollectorsCount: async (_: any) =>

--- a/group-generators/helpers/data-providers/index.ts
+++ b/group-generators/helpers/data-providers/index.ts
@@ -227,8 +227,6 @@ export const dataProvidersAPIEndpoints = {
       new LensProviderBigQuery().getPublicationReactorsCount(_),
     getHashtagMentionersCount: async (_: any) =>
       new LensProviderBigQuery().getHashtagMentionersCount(_),
-    getProfilesRankCount: async (_: any) =>
-      new LensProviderBigQuery().getProfilesRankingCount(_),
   },
   MirrorXyzSubgraphProvider: {
     getPostCollectorsCount: async (_: any) =>

--- a/group-generators/helpers/data-providers/index.ts
+++ b/group-generators/helpers/data-providers/index.ts
@@ -30,6 +30,7 @@ import { HiveProvider } from "./hive";
 import HiveInterfaceSchema from "./hive/interface-schema.json";
 import { JsonRpcProvider } from "./json-rpc";
 import { LensProvider } from "./lens";
+import { LensProviderBigQuery } from "./lens-bigquery";
 import lensInterfaceSchema from "./lens/interface-schema.json";
 import { MirrorXyzSubgraphProvider } from "./mirrorxyz";
 import mirrorxyzInterfaceSchema from "./mirrorxyz/interface-schema.json";
@@ -89,6 +90,7 @@ export const dataProviders = {
   HiveProvider,
   JsonRpcProvider,
   LensProvider,
+  LensProviderBigQuery,
   MirrorXyzSubgraphProvider,
   OtterSpaceSubgraphProvider,
   PoapSubgraphProvider,

--- a/group-generators/helpers/data-providers/lens-bigquery/index.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/index.ts
@@ -13,9 +13,12 @@ import {
   getPublicationReactorsCountQuery,
   getPublicationCommentersQuery,
   getPublicationCommentersCountQuery,
+  getProfileFromAddressQuery,
+  getProfileFromHandleQuery,
 } from "./queries";
 import { Hashtag, PublicationReaction } from "./types";
 import { BigQueryProvider, SupportedNetwork } from "@group-generators/helpers/data-providers/big-query";
+import { EnsProvider } from "@group-generators/helpers/data-providers/ens";
 import {
   ProfileId,
   PublicationId,
@@ -32,13 +35,15 @@ export class LensProviderBigQuery extends BigQueryProvider {
 
   public async getFollowers(profileId: ProfileId): Promise<FetchedData> {
     let dataProfiles: FetchedData = {};
-    const query = getFollowersQuery(profileId);
+    const resolvedProfileId = await this._getProfileIdFromAnySources(profileId);
+    const query = getFollowersQuery(resolvedProfileId);
     dataProfiles = await this.fetchAccounts(query);
     return dataProfiles;
   }
 
   public async getFollowersCount(profileId: ProfileId): Promise<number> {
-    const query = getFollowersCountQuery(profileId);
+    const resolvedProfileId = await this._getProfileIdFromAnySources(profileId);
+    const query = getFollowersCountQuery(resolvedProfileId);
     const count = await this.fetchCount(query);
     return count;
   }
@@ -124,5 +129,63 @@ export class LensProviderBigQuery extends BigQueryProvider {
     const query = getHashtagMentionersCountQuery(formatedHashtag);
     const count = await this.fetchCount(query);
     return count;
+  }
+
+  private async _getProfileFromAddress(address: string): Promise<ProfileId> {
+    const query = getProfileFromAddressQuery(address);
+    const response = await this.fetch(query);
+    if(response[0].length === 0) {
+      throw new Error(`Invalid input: No profile found for address: ${address}`);
+    }
+    const profileId = response[0][0]["profile_id"];
+    return {
+      profileId: profileId,
+    } as ProfileId;
+  }
+
+  private async _getProfileFromHandle(handle: string): Promise<ProfileId> {
+    const query = getProfileFromHandleQuery(handle);
+    const response = await this.fetch(query);
+    if(response[0].length === 0) {
+      throw new Error(`Invalid input: No profile found for handle: ${handle}`);
+    }
+    const profileId = response[0][0]["profile_id"];
+    return {
+      profileId: profileId,
+    } as ProfileId;
+  }
+
+  private async _getProfileIdFromAnySources(profileId: ProfileId): Promise<ProfileId> {
+    let formattedProfileId = {} as ProfileId;
+    // Check if input is a valid eth address
+    if (profileId.profileId.match(/^0x[a-fA-F0-9]{40}$/g)) {
+      formattedProfileId = await this._getProfileFromAddress(profileId.profileId);
+    }
+    // Check if input is a valid ENS
+    else if (profileId.profileId.match("\\.eth$")) {
+      const ensProvider = new EnsProvider();
+      const ethAddress = await ensProvider.resolveEnsFromJsonRpc(profileId.profileId);
+      if(ethAddress === "0x0000000000000000000000000000000000000000"){
+        throw new Error("Invalid input: No profile found for this ENS");
+      }
+      formattedProfileId = await this._getProfileFromAddress(ethAddress);
+    }
+    // Check if input is a valid lens handle
+    else if (profileId.profileId.match("\\.lens$")) {
+      formattedProfileId = await this._getProfileFromHandle(profileId.profileId);
+    }
+    // Check if input is a valid lens profile id
+    else if (profileId.profileId.match(/^0x[a-fA-F0-9]{0,39}$/g)) {
+      formattedProfileId = profileId;
+    }
+    // Check if input is a valid lens handle without .lens
+    else {
+      const forcedLensHandle = profileId.profileId + ".lens";
+      formattedProfileId = await this._getProfileFromHandle(forcedLensHandle);
+    }
+    if(!formattedProfileId) {
+      throw new Error(`Invalid input: No profile found for ${profileId.profileId}`);
+    }
+    return formattedProfileId;
   }
 }

--- a/group-generators/helpers/data-providers/lens-bigquery/index.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/index.ts
@@ -1,0 +1,250 @@
+import {
+  getFollowersCountQuery,
+  getFollowersQuery,
+} from "./queries";
+import { BigQueryProvider, SupportedNetwork } from "@group-generators/helpers/data-providers/big-query";
+import {
+  // ExploreProfileType,
+  // FollowerType,
+  // GetFollowersType,
+  // GetWhoCollectedPublicationType,
+  // GetWhoMirroredPublicationType,
+  // ProfileType,
+  ProfileId,
+  // PublicationId,
+  // Wallet,
+} from "@group-generators/helpers/data-providers/lens/types";
+// import { EnsProvider } from "@group-generators/helpers/data-providers/ens";
+// import { retryRequest } from "@group-generators/helpers/data-providers/utils/utils";
+import { FetchedData } from "topics/group";
+
+export class LensProviderBigQuery extends BigQueryProvider {
+
+  constructor() {
+    super({
+      network: SupportedNetwork.POLYGON,
+    });
+  }
+
+  public async getFollowers(profileId: ProfileId): Promise<FetchedData> {
+    let dataProfiles: FetchedData = {};
+    const query = getFollowersQuery(profileId);
+    dataProfiles = await this.fetch(query);
+    return dataProfiles;
+  }
+
+  public async getFollowersCount(profileId: ProfileId): Promise<number> {
+    const query = getFollowersCountQuery(profileId);
+    const count = await this.fetchCount(query);
+    return count;
+  }
+
+
+//   public async getWhoCollectedPublication(
+//     publication: PublicationId
+//   ): Promise<FetchedData> {
+//     const dataProfiles: FetchedData = {};
+//     for await (const item of this._getWhoCollectedPublication(publication)) {
+//       dataProfiles[item.address] = 1;
+//     }
+//     return dataProfiles;
+//   }
+
+//   public async getPublicationCollectorsCount(
+//     publication: PublicationId
+//   ): Promise<number> {
+//     const publicationStats = await getPublicationStatsQuery(
+//       this,
+//       publication.publicationId
+//     );
+//     return publicationStats.publication.stats.totalAmountOfCollects;
+//   }
+
+//   public async getWhoMirroredPublication(
+//     publication: PublicationId
+//   ): Promise<FetchedData> {
+//     const dataProfiles: FetchedData = {};
+//     for await (const item of this._getWhoMirroredPublication(publication)) {
+//       dataProfiles[item.ownedBy] = 1;
+//     }
+//     return dataProfiles;
+//   }
+
+//   public async getPublicationMirrorsCount(
+//     publication: PublicationId
+//   ): Promise<number> {
+//     const publicationStats = await getPublicationStatsQuery(
+//       this,
+//       publication.publicationId
+//     );
+//     return publicationStats.publication.stats.totalAmountOfMirrors;
+//   }
+
+//   private async *_getFollowers({
+//     profileId,
+//   }: ProfileId): AsyncGenerator<FollowerType, void, undefined> {
+//     let cursor = "";
+//     let lensFollowers: GetFollowersType;
+
+//     const resolvedProfileId = await this._getProfileIdFromAnySources(profileId);
+
+//     do {
+//       lensFollowers = await getFollowersQuery(this, resolvedProfileId, cursor);
+//       yield* lensFollowers.followers.items;
+//       cursor = lensFollowers.followers.pageInfo.next;
+//     } while (lensFollowers.followers.items.length > 0);
+//   }
+
+//   public async getAllProfiles(): Promise<FetchedData> {
+//     const dataProfiles: FetchedData = {};
+//     let profileChunks = [];
+//     let profilesFetched = 0;
+//     let continueFetch = true;
+//     let offset = 0;
+//     const chunk = 50;
+//     const parallelChunks = 10;
+
+//     while (continueFetch) {
+//       profileChunks = [];
+//       for (let i = offset; i <= offset + parallelChunks * chunk; i += chunk) {
+//         profileChunks.push('{"offset":' + i + "}");
+//       }
+//       offset += parallelChunks * chunk;
+
+//       const profileChunksPromise = profileChunks.map((chunk) =>
+//         retryRequest(exploreProfilesQuery(this, chunk))
+//       );
+//       await Promise.all(profileChunksPromise)
+//         .then((profiles) => {
+//           for (const profile of profiles) {
+//             if (profile == null || profile.exploreProfiles.items.length == 0) {
+//               continueFetch = false;
+//             }
+//             for (const item of profile.exploreProfiles.items) {
+//               dataProfiles[item.ownedBy] = 1;
+//               profilesFetched++;
+//             }
+//           }
+//           console.log(`Lens profiles count: ${profilesFetched}`);
+//         })
+//         .catch((error) => {
+//           throw new Error(error);
+//         });
+//     }
+
+//     return dataProfiles;
+//   }
+
+//   public async *exploreProfilesWithMaxRank(
+//     maxRank: number
+//   ): AsyncGenerator<ProfileType, void, undefined> {
+//     let cursor = "";
+//     let counter = 0;
+//     let lensProfiles: ExploreProfileType;
+//     do {
+//       lensProfiles = await exploreRankedProfilesQuery(this, cursor);
+//       yield* lensProfiles.exploreProfiles.items;
+//       cursor = lensProfiles.exploreProfiles.pageInfo.next;
+//       counter++;
+//     } while (counter < maxRank / 50);
+//   }
+
+//   private async *_getWhoCollectedPublication({
+//     publicationId,
+//   }: PublicationId): AsyncGenerator<Wallet, void, undefined> {
+//     let cursor = "";
+//     let lensCollectors: GetWhoCollectedPublicationType;
+//     do {
+//       lensCollectors = await getWhoCollectedPublicationQuery(
+//         this,
+//         publicationId,
+//         cursor
+//       );
+//       yield* lensCollectors.whoCollectedPublication.items;
+//       cursor = lensCollectors.whoCollectedPublication.pageInfo.next;
+//     } while (lensCollectors.whoCollectedPublication.items.length > 0);
+//   }
+
+//   private async *_getWhoMirroredPublication({
+//     publicationId,
+//   }: PublicationId): AsyncGenerator<ProfileType, void, undefined> {
+//     let cursor = "";
+//     let lensMirrorers: GetWhoMirroredPublicationType;
+//     do {
+//       lensMirrorers = await getWhoMirroredPublicationQuery(
+//         this,
+//         publicationId,
+//         cursor
+//       );
+//       yield* lensMirrorers.profiles.items;
+//       cursor = lensMirrorers.profiles.pageInfo.next;
+//     } while (lensMirrorers.profiles.items.length > 0);
+//   }
+
+//   public async *getProfileWithHandles(
+//     handles: string[]
+//   ): AsyncGenerator<ProfileType, void, undefined> {
+//     for (const handle of handles) {
+//       const profile = await getProfileWithHandleQuery(this, handle);
+//       yield profile.profile;
+//     }
+//   }
+
+//   private async _getDefaultProfileWithEthAddress(
+//     ethereumAddress: string
+//   ): Promise<ProfileType> {
+//     const response = await getDefaultProfileWithEthAddressQuery(
+//       this,
+//       ethereumAddress
+//     );
+//     return response.defaultProfile;
+//   }
+
+//   /**
+//    * Use this method to resolve a lens profile id from either an ethereum address, a lens profile id, a lens handle, a ens name.
+//    * @param input A string from either a ethereum address, a lens profile id, a lens handle, a ens name.
+//    * @returns The lens profile id as a string.
+//    */
+//   public async _getProfileIdFromAnySources(input: string): Promise<string> {
+//     try {
+//       // Check if input is a valid eth address
+//       if (input.match(/^0x[a-fA-F0-9]{40}$/g)) {
+//         const profile = await this._getDefaultProfileWithEthAddress(input);
+//         if (profile?.id) {
+//           return profile.id;
+//         } else {
+//           throw new Error("No profile found for this ethereum address");
+//         }
+//       }
+//       // Check if input is a valid lens profile id
+//       if (input.match(/^0x[a-fA-F0-9]{0,39}$/g)) {
+//         return input;
+//       }
+//       // Check if input is a valid lens handle
+//       if (input.includes(".lens")) {
+//         const response = await getProfileWithHandleQuery(this, input);
+//         if (response?.profile?.id) {
+//           return response.profile.id;
+//         } else {
+//           throw new Error("No profile found for this Lens handle");
+//         }
+//       }
+//       // Check if input is a valid ens name
+//       if (input.includes(".eth")) {
+//         const ensProvider = new EnsProvider();
+//         const ethAddress = await ensProvider.resolveEnsFromJsonRpc(input);
+//         const profile = await this._getDefaultProfileWithEthAddress(ethAddress);
+
+//         if (profile?.id) {
+//           return profile.id;
+//         } else {
+//           throw new Error("No profile found for this ENS");
+//         }
+//       } else {
+//         throw new Error("Invalid input format");
+//       }
+//     } catch (err) {
+//       throw new Error("Invalid input");
+//     }
+//   }
+}

--- a/group-generators/helpers/data-providers/lens-bigquery/index.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/index.ts
@@ -16,13 +16,9 @@ import {
   getProfileFromAddressQuery,
   getProfileFromHandleQuery,
 } from "./queries";
-import { Hashtag, PublicationReaction } from "./types";
+import { Hashtag, Profile, Publication, PublicationReaction, RankingCriteria } from "./types";
 import { BigQueryProvider, SupportedNetwork } from "@group-generators/helpers/data-providers/big-query";
 import { EnsProvider } from "@group-generators/helpers/data-providers/ens";
-import {
-  ProfileId,
-  PublicationId,
-} from "@group-generators/helpers/data-providers/lens/types";
 import { FetchedData } from "topics/group";
 
 export class LensProviderBigQuery extends BigQueryProvider {
@@ -33,56 +29,56 @@ export class LensProviderBigQuery extends BigQueryProvider {
     });
   }
 
-  public async getFollowers(profileId: ProfileId): Promise<FetchedData> {
+  public async getFollowers(profile: Profile): Promise<FetchedData> {
     let dataProfiles: FetchedData = {};
-    const resolvedProfileId = await this._getProfileIdFromAnySources(profileId);
-    const query = getFollowersQuery(resolvedProfileId);
+    const resolvedProfile = await this._getProfileIdFromAnySources(profile);
+    const query = getFollowersQuery(resolvedProfile);
     dataProfiles = await this.fetchAccounts(query);
     return dataProfiles;
   }
 
-  public async getFollowersCount(profileId: ProfileId): Promise<number> {
-    const resolvedProfileId = await this._getProfileIdFromAnySources(profileId);
-    const query = getFollowersCountQuery(resolvedProfileId);
+  public async getFollowersCount(profile: Profile): Promise<number> {
+    const resolvedProfile = await this._getProfileIdFromAnySources(profile);
+    const query = getFollowersCountQuery(resolvedProfile);
     const count = await this.fetchCount(query);
     return count;
   }
 
-  public async getPublicationCollectors(publication: PublicationId): Promise<FetchedData> {
+  public async getPublicationCollectors(publication: Publication): Promise<FetchedData> {
     let dataProfiles: FetchedData = {};
     const query = getPublicationCollectorsQuery(publication);
     dataProfiles = await this.fetchAccounts(query);
     return dataProfiles;
   }
 
-  public async getPublicationCollectorsCount(publication: PublicationId): Promise<number> {
+  public async getPublicationCollectorsCount(publication: Publication): Promise<number> {
     const query = getPublicationCollectorsCountQuery(publication);
     const count = await this.fetchCount(query);
     return count;
   }
 
-  public async getPublicationMirrorers(publication: PublicationId): Promise<FetchedData> {
+  public async getPublicationMirrorers(publication: Publication): Promise<FetchedData> {
     let dataProfiles: FetchedData = {};
     const query = getPublicationMirrorersQuery(publication);
     dataProfiles = await this.fetchAccounts(query);
     return dataProfiles;
   }
 
-  public async getPublicationMirrorersCount(publication: PublicationId): Promise<number> {
+  public async getPublicationMirrorersCount(publication: Publication): Promise<number> {
     const query = getPublicationMirrorersCountQuery(publication);
     const count = await this.fetchCount(query);
     return count;
   }
 
-  public async getProfilesRank(rankingCriteria: {rank: number}): Promise<FetchedData> {
+  public async getProfilesRank(rankingCriteria: RankingCriteria): Promise<FetchedData> {
     let dataProfiles: FetchedData = {};
-    const query = getProfilesRankQuery(rankingCriteria.rank);
+    const query = getProfilesRankQuery(rankingCriteria);
     dataProfiles = await this.fetchAccounts(query);
     return dataProfiles;
   }
 
-  public async getProfilesRankCount(rankingCriteria: {rank: number}): Promise<number> {
-    const query = getProfilesRankCountQuery(rankingCriteria.rank);
+  public async getProfilesRankCount(rankingCriteria: RankingCriteria): Promise<number> {
+    const query = getProfilesRankCountQuery(rankingCriteria);
     const count = await this.fetchCount(query);
     if(count) {
       return rankingCriteria.rank;
@@ -103,15 +99,15 @@ export class LensProviderBigQuery extends BigQueryProvider {
     return count;
   }
 
-  public async getPublicationCommenters(publicationId: PublicationId): Promise<FetchedData> {
+  public async getPublicationCommenters(publication: Publication): Promise<FetchedData> {
     let dataProfiles: FetchedData = {};
-    const query = getPublicationCommentersQuery(publicationId);
+    const query = getPublicationCommentersQuery(publication);
     dataProfiles = await this.fetchAccounts(query);
     return dataProfiles;
   }
 
-  public async getPublicationCommentersCount(publicationId: PublicationId): Promise<number> {
-    const query = getPublicationCommentersCountQuery(publicationId);
+  public async getPublicationCommentersCount(publication: Publication): Promise<number> {
+    const query = getPublicationCommentersCountQuery(publication);
     const count = await this.fetchCount(query);
     return count;
   }
@@ -131,7 +127,7 @@ export class LensProviderBigQuery extends BigQueryProvider {
     return count;
   }
 
-  private async _getProfileFromAddress(address: string): Promise<ProfileId> {
+  private async _getProfileFromAddress(address: string): Promise<Profile> {
     const query = getProfileFromAddressQuery(address);
     const response = await this.fetch(query);
     if(response[0].length === 0) {
@@ -140,10 +136,10 @@ export class LensProviderBigQuery extends BigQueryProvider {
     const profileId = response[0][0]["profile_id"];
     return {
       profileId: profileId,
-    } as ProfileId;
+    } as Profile;
   }
 
-  private async _getProfileFromHandle(handle: string): Promise<ProfileId> {
+  private async _getProfileFromHandle(handle: string): Promise<Profile> {
     const query = getProfileFromHandleQuery(handle);
     const response = await this.fetch(query);
     if(response[0].length === 0) {
@@ -152,40 +148,40 @@ export class LensProviderBigQuery extends BigQueryProvider {
     const profileId = response[0][0]["profile_id"];
     return {
       profileId: profileId,
-    } as ProfileId;
+    } as Profile;
   }
 
-  private async _getProfileIdFromAnySources(profileId: ProfileId): Promise<ProfileId> {
-    let formattedProfileId = {} as ProfileId;
+  private async _getProfileIdFromAnySources(profile: Profile): Promise<Profile> {
+    let formattedProfile = {} as Profile;
     // Check if input is a valid eth address
-    if (profileId.profileId.match(/^0x[a-fA-F0-9]{40}$/g)) {
-      formattedProfileId = await this._getProfileFromAddress(profileId.profileId);
+    if (profile.profileId.match(/^0x[a-fA-F0-9]{40}$/g)) {
+      formattedProfile = await this._getProfileFromAddress(profile.profileId);
     }
     // Check if input is a valid ENS
-    else if (profileId.profileId.match("\\.eth$")) {
+    else if (profile.profileId.match("\\.eth$")) {
       const ensProvider = new EnsProvider();
-      const ethAddress = await ensProvider.resolveEnsFromJsonRpc(profileId.profileId);
+      const ethAddress = await ensProvider.resolveEnsFromJsonRpc(profile.profileId);
       if(ethAddress === "0x0000000000000000000000000000000000000000"){
         throw new Error("Invalid input: No profile found for this ENS");
       }
-      formattedProfileId = await this._getProfileFromAddress(ethAddress);
+      formattedProfile = await this._getProfileFromAddress(ethAddress);
     }
     // Check if input is a valid lens handle
-    else if (profileId.profileId.match("\\.lens$")) {
-      formattedProfileId = await this._getProfileFromHandle(profileId.profileId);
+    else if (profile.profileId.match("\\.lens$")) {
+      formattedProfile = await this._getProfileFromHandle(profile.profileId);
     }
     // Check if input is a valid lens profile id
-    else if (profileId.profileId.match(/^0x[a-fA-F0-9]{0,39}$/g)) {
-      formattedProfileId = profileId;
+    else if (profile.profileId.match(/^0x[a-fA-F0-9]{0,39}$/g)) {
+      formattedProfile = profile;
     }
     // Check if input is a valid lens handle without .lens
     else {
-      const forcedLensHandle = profileId.profileId + ".lens";
-      formattedProfileId = await this._getProfileFromHandle(forcedLensHandle);
+      const forcedLensHandle = profile.profileId + ".lens";
+      formattedProfile = await this._getProfileFromHandle(forcedLensHandle);
     }
-    if(!formattedProfileId) {
-      throw new Error(`Invalid input: No profile found for ${profileId.profileId}`);
+    if(!formattedProfile) {
+      throw new Error(`Invalid input: No profile found for ${profile.profileId}`);
     }
-    return formattedProfileId;
+    return formattedProfile;
   }
 }

--- a/group-generators/helpers/data-providers/lens-bigquery/index.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/index.ts
@@ -11,8 +11,10 @@ import {
   getWhoReactedToPublicationCountQuery,
   getWhoCommentedPublicationQuery,
   getWhoCommentedPublicationCountQuery,
+  getHashtagMentionersQuery,
+  getHashtagMentionersCountQuery,
 } from "./queries";
-import { PublicationReaction } from "./types";
+import { Hashtag, PublicationReaction } from "./types";
 import { BigQueryProvider, SupportedNetwork } from "@group-generators/helpers/data-providers/big-query";
 // import { EnsProvider } from "@group-generators/helpers/data-providers/ens";
 import {
@@ -118,24 +120,19 @@ export class LensProviderBigQuery extends BigQueryProvider {
     return count;
   }
 
+  public async getHashtagMentioners(hashtag: Hashtag): Promise<FetchedData> {
+    let dataProfiles: FetchedData = {};
+    const formatedHashtag: Hashtag = {hashtag: hashtag.hashtag.toLowerCase()};
+    const query = getHashtagMentionersQuery(formatedHashtag);
+    dataProfiles = await this.fetch(query);
+    return dataProfiles;
+  }
 
-
-
-
-
-//   public async *exploreProfilesWithMaxRank(
-//     maxRank: number
-//   ): AsyncGenerator<ProfileType, void, undefined> {
-//     let cursor = "";
-//     let counter = 0;
-//     let lensProfiles: ExploreProfileType;
-//     do {
-//       lensProfiles = await exploreRankedProfilesQuery(this, cursor);
-//       yield* lensProfiles.exploreProfiles.items;
-//       cursor = lensProfiles.exploreProfiles.pageInfo.next;
-//       counter++;
-//     } while (counter < maxRank / 50);
-//   }
-
+  public async getHashtagMentionersCount(hashtag: Hashtag): Promise<number> {
+    const formatedHashtag: Hashtag = {hashtag: hashtag.hashtag.toLowerCase()};
+    const query = getHashtagMentionersCountQuery(formatedHashtag);
+    const count = await this.fetchCount(query);
+    return count;
+  }
 }
 

--- a/group-generators/helpers/data-providers/lens-bigquery/index.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/index.ts
@@ -19,7 +19,7 @@ import { BigQueryProvider, SupportedNetwork } from "@group-generators/helpers/da
 import { EnsProvider } from "@group-generators/helpers/data-providers/ens";
 import { FetchedData } from "topics/group";
 
-export class LensProviderBigQuery extends BigQueryProvider {
+export class LensBigQueryProvider extends BigQueryProvider {
 
   constructor() {
     super({

--- a/group-generators/helpers/data-providers/lens-bigquery/index.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/index.ts
@@ -7,7 +7,10 @@ import {
   getWhoMirroredPublicationCountQuery,
   getProfilesRankQuery,
   getProfilesRankCountQuery,
+  getPublicationReactorsQuery,
+  getPublicationReactorsCountQuery,
 } from "./queries";
+import { PublicationReaction } from "./types";
 import { BigQueryProvider, SupportedNetwork } from "@group-generators/helpers/data-providers/big-query";
 // import { EnsProvider } from "@group-generators/helpers/data-providers/ens";
 import {
@@ -84,6 +87,19 @@ export class LensProviderBigQuery extends BigQueryProvider {
     if(count) {
       return rankingCriteria.rank;
     }
+    return count;
+  }
+
+  public async getPublicationReactors(publicationReaction: PublicationReaction): Promise<FetchedData> {
+    let dataProfiles: FetchedData = {};
+    const query = getPublicationReactorsQuery(publicationReaction);
+    dataProfiles = await this.fetch(query);
+    return dataProfiles;
+  }
+
+  public async getPublicationReactorsCount(publicationReaction: PublicationReaction): Promise<number> {
+    const query = getPublicationReactorsCountQuery(publicationReaction);
+    const count = await this.fetchCount(query);
     return count;
   }
 

--- a/group-generators/helpers/data-providers/lens-bigquery/index.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/index.ts
@@ -159,6 +159,9 @@ export class LensProviderBigQuery extends BigQueryProvider {
     let formattedProfile = {} as Profile;
     // Check if input is a valid eth address
     if (profile.profileId.match(/^0x[a-fA-F0-9]{40}$/g)) {
+      if(profile.profileId === "0x0000000000000000000000000000000000000000"){
+        throw new Error("Invalid input: No existing profile for the null address");
+      }
       formattedProfile = await this._getProfileFromAddress(profile.profileId);
     }
     // Check if input is a valid ENS

--- a/group-generators/helpers/data-providers/lens-bigquery/index.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/index.ts
@@ -7,8 +7,8 @@ import {
   getWhoMirroredPublicationCountQuery,
   getProfilesRankQuery,
   getProfilesRankCountQuery,
-  getPublicationReactorsQuery,
-  getPublicationReactorsCountQuery,
+  getWhoReactedToPublicationQuery,
+  getWhoReactedToPublicationCountQuery,
   getWhoCommentedPublicationQuery,
   getWhoCommentedPublicationCountQuery,
 } from "./queries";
@@ -92,15 +92,15 @@ export class LensProviderBigQuery extends BigQueryProvider {
     return count;
   }
 
-  public async getPublicationReactors(publicationReaction: PublicationReaction): Promise<FetchedData> {
+  public async getWhoReactedToPublication(publicationReaction: PublicationReaction): Promise<FetchedData> {
     let dataProfiles: FetchedData = {};
-    const query = getPublicationReactorsQuery(publicationReaction);
+    const query = getWhoReactedToPublicationQuery(publicationReaction);
     dataProfiles = await this.fetch(query);
     return dataProfiles;
   }
 
-  public async getPublicationReactorsCount(publicationReaction: PublicationReaction): Promise<number> {
-    const query = getPublicationReactorsCountQuery(publicationReaction);
+  public async getWhoReactedToPublicationCount(publicationReaction: PublicationReaction): Promise<number> {
+    const query = getWhoReactedToPublicationCountQuery(publicationReaction);
     const count = await this.fetchCount(query);
     return count;
   }

--- a/group-generators/helpers/data-providers/lens-bigquery/index.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/index.ts
@@ -1,8 +1,6 @@
 import {
   getFollowersCountQuery,
   getFollowersQuery,
-  getProfilesRankQuery,
-  getProfilesRankCountQuery,
   getHashtagMentionersQuery,
   getHashtagMentionersCountQuery,
   getPublicationCollectorsQuery,
@@ -15,6 +13,8 @@ import {
   getPublicationCommentersCountQuery,
   getProfileFromAddressQuery,
   getProfileFromHandleQuery,
+  getProfilesRankingQuery,
+  getProfilesRankingCountQuery,
 } from "./queries";
 import { Hashtag, Profile, Publication, PublicationReaction, RankingCriteria } from "./types";
 import { BigQueryProvider, SupportedNetwork } from "@group-generators/helpers/data-providers/big-query";
@@ -115,15 +115,15 @@ export class LensProviderBigQuery extends BigQueryProvider {
     return count;
   }
 
-  public async getProfilesRank(rankingCriteria: RankingCriteria): Promise<FetchedData> {
+  public async getFirstsProfilesRanking(rankingCriteria: RankingCriteria): Promise<FetchedData> {
     let dataProfiles: FetchedData = {};
-    const query = getProfilesRankQuery(rankingCriteria);
+    const query = getProfilesRankingQuery(rankingCriteria);
     dataProfiles = await this.fetchAccounts(query);
     return dataProfiles;
   }
 
-  public async getProfilesRankCount(rankingCriteria: RankingCriteria): Promise<number> {
-    const query = getProfilesRankCountQuery(rankingCriteria);
+  public async getProfilesRankingCount(rankingCriteria: RankingCriteria): Promise<number> {
+    const query = getProfilesRankingCountQuery(rankingCriteria);
     const count = await this.fetchCount(query);
     if(count) {
       return rankingCriteria.rank;

--- a/group-generators/helpers/data-providers/lens-bigquery/index.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/index.ts
@@ -13,10 +13,8 @@ import {
   getPublicationCommentersCountQuery,
   getProfileFromAddressQuery,
   getProfileFromHandleQuery,
-  getProfilesRankingQuery,
-  getProfilesRankingCountQuery,
 } from "./queries";
-import { Hashtag, Profile, Publication, PublicationReaction, RankingCriteria } from "./types";
+import { Hashtag, Profile, Publication, PublicationReaction } from "./types";
 import { BigQueryProvider, SupportedNetwork } from "@group-generators/helpers/data-providers/big-query";
 import { EnsProvider } from "@group-generators/helpers/data-providers/ens";
 import { FetchedData } from "topics/group";
@@ -112,22 +110,6 @@ export class LensProviderBigQuery extends BigQueryProvider {
     }  
     const query = getHashtagMentionersCountQuery(hashtag);
     const count = await this.fetchCount(query);
-    return count;
-  }
-
-  public async getFirstsProfilesRanking(rankingCriteria: RankingCriteria): Promise<FetchedData> {
-    let dataProfiles: FetchedData = {};
-    const query = getProfilesRankingQuery(rankingCriteria);
-    dataProfiles = await this.fetchAccounts(query);
-    return dataProfiles;
-  }
-
-  public async getProfilesRankingCount(rankingCriteria: RankingCriteria): Promise<number> {
-    const query = getProfilesRankingCountQuery(rankingCriteria);
-    const count = await this.fetchCount(query);
-    if(count) {
-      return rankingCriteria.rank;
-    }
     return count;
   }
 

--- a/group-generators/helpers/data-providers/lens-bigquery/index.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/index.ts
@@ -33,7 +33,7 @@ export class LensProviderBigQuery extends BigQueryProvider {
   public async getFollowers(profileId: ProfileId): Promise<FetchedData> {
     let dataProfiles: FetchedData = {};
     const query = getFollowersQuery(profileId);
-    dataProfiles = await this.fetch(query);
+    dataProfiles = await this.fetchAccounts(query);
     return dataProfiles;
   }
 
@@ -46,7 +46,7 @@ export class LensProviderBigQuery extends BigQueryProvider {
   public async getPublicationCollectors(publication: PublicationId): Promise<FetchedData> {
     let dataProfiles: FetchedData = {};
     const query = getPublicationCollectorsQuery(publication);
-    dataProfiles = await this.fetch(query);
+    dataProfiles = await this.fetchAccounts(query);
     return dataProfiles;
   }
 
@@ -59,7 +59,7 @@ export class LensProviderBigQuery extends BigQueryProvider {
   public async getPublicationMirrorers(publication: PublicationId): Promise<FetchedData> {
     let dataProfiles: FetchedData = {};
     const query = getPublicationMirrorersQuery(publication);
-    dataProfiles = await this.fetch(query);
+    dataProfiles = await this.fetchAccounts(query);
     return dataProfiles;
   }
 
@@ -72,7 +72,7 @@ export class LensProviderBigQuery extends BigQueryProvider {
   public async getProfilesRank(rankingCriteria: {rank: number}): Promise<FetchedData> {
     let dataProfiles: FetchedData = {};
     const query = getProfilesRankQuery(rankingCriteria.rank);
-    dataProfiles = await this.fetch(query);
+    dataProfiles = await this.fetchAccounts(query);
     return dataProfiles;
   }
 
@@ -88,7 +88,7 @@ export class LensProviderBigQuery extends BigQueryProvider {
   public async getPublicationReactors(publicationReaction: PublicationReaction): Promise<FetchedData> {
     let dataProfiles: FetchedData = {};
     const query = getPublicationReactorsQuery(publicationReaction);
-    dataProfiles = await this.fetch(query);
+    dataProfiles = await this.fetchAccounts(query);
     return dataProfiles;
   }
 
@@ -101,7 +101,7 @@ export class LensProviderBigQuery extends BigQueryProvider {
   public async getPublicationCommenters(publicationId: PublicationId): Promise<FetchedData> {
     let dataProfiles: FetchedData = {};
     const query = getPublicationCommentersQuery(publicationId);
-    dataProfiles = await this.fetch(query);
+    dataProfiles = await this.fetchAccounts(query);
     return dataProfiles;
   }
 
@@ -115,7 +115,7 @@ export class LensProviderBigQuery extends BigQueryProvider {
     let dataProfiles: FetchedData = {};
     const formatedHashtag: Hashtag = {hashtag: hashtag.hashtag.toLowerCase()};
     const query = getHashtagMentionersQuery(formatedHashtag);
-    dataProfiles = await this.fetch(query);
+    dataProfiles = await this.fetchAccounts(query);
     return dataProfiles;
   }
 
@@ -126,4 +126,3 @@ export class LensProviderBigQuery extends BigQueryProvider {
     return count;
   }
 }
-

--- a/group-generators/helpers/data-providers/lens-bigquery/index.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/index.ts
@@ -1,8 +1,10 @@
 import {
   getFollowersCountQuery,
   getFollowersQuery,
-  getWhoCollectedPublicationsQuery,
-  getWhoCollectedPublicationsCountQuery,
+  getWhoCollectedPublicationQuery,
+  getWhoCollectedPublicationCountQuery,
+  getWhoMirroredPublicationQuery,
+  getWhoMirroredPublicationCountQuery,
 } from "./queries";
 import { BigQueryProvider, SupportedNetwork } from "@group-generators/helpers/data-providers/big-query";
 // import { EnsProvider } from "@group-generators/helpers/data-providers/ens";
@@ -43,17 +45,29 @@ export class LensProviderBigQuery extends BigQueryProvider {
 
   public async getWhoCollectedPublication(publication: PublicationId): Promise<FetchedData> {
     let dataProfiles: FetchedData = {};
-    const query = getWhoCollectedPublicationsQuery(publication);
+    const query = getWhoCollectedPublicationQuery(publication);
     dataProfiles = await this.fetch(query);
     return dataProfiles;
   }
 
   public async getWhoCollectedPublicationCount(publication: PublicationId): Promise<number> {
-    const query = getWhoCollectedPublicationsCountQuery(publication);
+    const query = getWhoCollectedPublicationCountQuery(publication);
     const count = await this.fetchCount(query);
     return count;
   }
 
+  public async getWhoMirroredPublication(publication: PublicationId): Promise<FetchedData> {
+    let dataProfiles: FetchedData = {};
+    const query = getWhoMirroredPublicationQuery(publication);
+    dataProfiles = await this.fetch(query);
+    return dataProfiles;
+  }
+
+  public async getWhoMirroredPublicationCount(publication: PublicationId): Promise<number> {
+    const query = getWhoMirroredPublicationCountQuery(publication);
+    const count = await this.fetchCount(query);
+    return count;
+  }
 
 //   public async getWhoMirroredPublication(
 //     publication: PublicationId

--- a/group-generators/helpers/data-providers/lens-bigquery/index.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/index.ts
@@ -1,8 +1,11 @@
 import {
   getFollowersCountQuery,
   getFollowersQuery,
+  getWhoCollectedPublicationsQuery,
+  getWhoCollectedPublicationsCountQuery,
 } from "./queries";
 import { BigQueryProvider, SupportedNetwork } from "@group-generators/helpers/data-providers/big-query";
+// import { EnsProvider } from "@group-generators/helpers/data-providers/ens";
 import {
   // ExploreProfileType,
   // FollowerType,
@@ -11,10 +14,9 @@ import {
   // GetWhoMirroredPublicationType,
   // ProfileType,
   ProfileId,
-  // PublicationId,
+  PublicationId,
   // Wallet,
 } from "@group-generators/helpers/data-providers/lens/types";
-// import { EnsProvider } from "@group-generators/helpers/data-providers/ens";
 // import { retryRequest } from "@group-generators/helpers/data-providers/utils/utils";
 import { FetchedData } from "topics/group";
 
@@ -39,26 +41,19 @@ export class LensProviderBigQuery extends BigQueryProvider {
     return count;
   }
 
+  public async getWhoCollectedPublication(publication: PublicationId): Promise<FetchedData> {
+    let dataProfiles: FetchedData = {};
+    const query = getWhoCollectedPublicationsQuery(publication);
+    dataProfiles = await this.fetch(query);
+    return dataProfiles;
+  }
 
-//   public async getWhoCollectedPublication(
-//     publication: PublicationId
-//   ): Promise<FetchedData> {
-//     const dataProfiles: FetchedData = {};
-//     for await (const item of this._getWhoCollectedPublication(publication)) {
-//       dataProfiles[item.address] = 1;
-//     }
-//     return dataProfiles;
-//   }
+  public async getWhoCollectedPublicationCount(publication: PublicationId): Promise<number> {
+    const query = getWhoCollectedPublicationsCountQuery(publication);
+    const count = await this.fetchCount(query);
+    return count;
+  }
 
-//   public async getPublicationCollectorsCount(
-//     publication: PublicationId
-//   ): Promise<number> {
-//     const publicationStats = await getPublicationStatsQuery(
-//       this,
-//       publication.publicationId
-//     );
-//     return publicationStats.publication.stats.totalAmountOfCollects;
-//   }
 
 //   public async getWhoMirroredPublication(
 //     publication: PublicationId
@@ -190,61 +185,62 @@ export class LensProviderBigQuery extends BigQueryProvider {
 //     }
 //   }
 
-//   private async _getDefaultProfileWithEthAddress(
-//     ethereumAddress: string
-//   ): Promise<ProfileType> {
-//     const response = await getDefaultProfileWithEthAddressQuery(
-//       this,
-//       ethereumAddress
-//     );
-//     return response.defaultProfile;
-//   }
+  // private async _getDefaultProfileWithEthAddress(
+  //   ethereumAddress: string
+  // ): Promise<ProfileType> {
+  //   const response = await getDefaultProfileWithEthAddressQuery(
+  //     this,
+  //     ethereumAddress
+  //   );
+  //   return response.defaultProfile;
+  // }
 
-//   /**
-//    * Use this method to resolve a lens profile id from either an ethereum address, a lens profile id, a lens handle, a ens name.
-//    * @param input A string from either a ethereum address, a lens profile id, a lens handle, a ens name.
-//    * @returns The lens profile id as a string.
-//    */
-//   public async _getProfileIdFromAnySources(input: string): Promise<string> {
-//     try {
-//       // Check if input is a valid eth address
-//       if (input.match(/^0x[a-fA-F0-9]{40}$/g)) {
-//         const profile = await this._getDefaultProfileWithEthAddress(input);
-//         if (profile?.id) {
-//           return profile.id;
-//         } else {
-//           throw new Error("No profile found for this ethereum address");
-//         }
-//       }
-//       // Check if input is a valid lens profile id
-//       if (input.match(/^0x[a-fA-F0-9]{0,39}$/g)) {
-//         return input;
-//       }
-//       // Check if input is a valid lens handle
-//       if (input.includes(".lens")) {
-//         const response = await getProfileWithHandleQuery(this, input);
-//         if (response?.profile?.id) {
-//           return response.profile.id;
-//         } else {
-//           throw new Error("No profile found for this Lens handle");
-//         }
-//       }
-//       // Check if input is a valid ens name
-//       if (input.includes(".eth")) {
-//         const ensProvider = new EnsProvider();
-//         const ethAddress = await ensProvider.resolveEnsFromJsonRpc(input);
-//         const profile = await this._getDefaultProfileWithEthAddress(ethAddress);
+  // /**
+  //  * Use this method to resolve a lens profile id from either an ethereum address, a lens profile id, a lens handle, a ens name.
+  //  * @param input A string from either a ethereum address, a lens profile id, a lens handle, a ens name.
+  //  * @returns The lens profile id as a string.
+  //  */
+  // public async _getProfileIdFromAnySources(input: string): Promise<string> {
+  //   try {
+  //     // Check if input is a valid eth address
+  //     if (input.match(/^0x[a-fA-F0-9]{40}$/g)) {
+  //       const profile = await this._getDefaultProfileWithEthAddress(input);
+  //       if (profile?.id) {
+  //         return profile.id;
+  //       } else {
+  //         throw new Error("No profile found for this ethereum address");
+  //       }
+  //     }
+  //     // Check if input is a valid lens profile id
+  //     if (input.match(/^0x[a-fA-F0-9]{0,39}$/g)) {
+  //       return input;
+  //     }
+  //     // Check if input is a valid lens handle
+  //     if (input.includes(".lens")) {
+  //       const response = await getProfileWithHandleQuery(this, input);
+  //       if (response?.profile?.id) {
+  //         return response.profile.id;
+  //       } else {
+  //         throw new Error("No profile found for this Lens handle");
+  //       }
+  //     }
+  //     // Check if input is a valid ens name
+  //     if (input.includes(".eth")) {
+  //       const ensProvider = new EnsProvider();
+  //       const ethAddress = await ensProvider.resolveEnsFromJsonRpc(input);
+  //       const profile = await this._getDefaultProfileWithEthAddress(ethAddress);
 
-//         if (profile?.id) {
-//           return profile.id;
-//         } else {
-//           throw new Error("No profile found for this ENS");
-//         }
-//       } else {
-//         throw new Error("Invalid input format");
-//       }
-//     } catch (err) {
-//       throw new Error("Invalid input");
-//     }
-//   }
+  //       if (profile?.id) {
+  //         return profile.id;
+  //       } else {
+  //         throw new Error("No profile found for this ENS");
+  //       }
+  //     } else {
+  //       throw new Error("Invalid input format");
+  //     }
+  //   } catch (err) {
+  //     throw new Error("Invalid input");
+  //   }
+  // }
 }
+

--- a/group-generators/helpers/data-providers/lens-bigquery/index.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/index.ts
@@ -5,6 +5,8 @@ import {
   getWhoCollectedPublicationCountQuery,
   getWhoMirroredPublicationQuery,
   getWhoMirroredPublicationCountQuery,
+  getProfilesRankQuery,
+  getProfilesRankCountQuery,
 } from "./queries";
 import { BigQueryProvider, SupportedNetwork } from "@group-generators/helpers/data-providers/big-query";
 // import { EnsProvider } from "@group-generators/helpers/data-providers/ens";
@@ -69,80 +71,26 @@ export class LensProviderBigQuery extends BigQueryProvider {
     return count;
   }
 
-//   public async getWhoMirroredPublication(
-//     publication: PublicationId
-//   ): Promise<FetchedData> {
-//     const dataProfiles: FetchedData = {};
-//     for await (const item of this._getWhoMirroredPublication(publication)) {
-//       dataProfiles[item.ownedBy] = 1;
-//     }
-//     return dataProfiles;
-//   }
+  public async getProfilesRank(rankingCriteria: {rank: number}): Promise<FetchedData> {
+    let dataProfiles: FetchedData = {};
+    const query = getProfilesRankQuery(rankingCriteria.rank);
+    dataProfiles = await this.fetch(query);
+    return dataProfiles;
+  }
 
-//   public async getPublicationMirrorsCount(
-//     publication: PublicationId
-//   ): Promise<number> {
-//     const publicationStats = await getPublicationStatsQuery(
-//       this,
-//       publication.publicationId
-//     );
-//     return publicationStats.publication.stats.totalAmountOfMirrors;
-//   }
+  public async getProfilesRankCount(rankingCriteria: {rank: number}): Promise<number> {
+    const query = getProfilesRankCountQuery(rankingCriteria.rank);
+    const count = await this.fetchCount(query);
+    if(count) {
+      return rankingCriteria.rank;
+    }
+    return count;
+  }
 
-//   private async *_getFollowers({
-//     profileId,
-//   }: ProfileId): AsyncGenerator<FollowerType, void, undefined> {
-//     let cursor = "";
-//     let lensFollowers: GetFollowersType;
 
-//     const resolvedProfileId = await this._getProfileIdFromAnySources(profileId);
 
-//     do {
-//       lensFollowers = await getFollowersQuery(this, resolvedProfileId, cursor);
-//       yield* lensFollowers.followers.items;
-//       cursor = lensFollowers.followers.pageInfo.next;
-//     } while (lensFollowers.followers.items.length > 0);
-//   }
 
-//   public async getAllProfiles(): Promise<FetchedData> {
-//     const dataProfiles: FetchedData = {};
-//     let profileChunks = [];
-//     let profilesFetched = 0;
-//     let continueFetch = true;
-//     let offset = 0;
-//     const chunk = 50;
-//     const parallelChunks = 10;
 
-//     while (continueFetch) {
-//       profileChunks = [];
-//       for (let i = offset; i <= offset + parallelChunks * chunk; i += chunk) {
-//         profileChunks.push('{"offset":' + i + "}");
-//       }
-//       offset += parallelChunks * chunk;
-
-//       const profileChunksPromise = profileChunks.map((chunk) =>
-//         retryRequest(exploreProfilesQuery(this, chunk))
-//       );
-//       await Promise.all(profileChunksPromise)
-//         .then((profiles) => {
-//           for (const profile of profiles) {
-//             if (profile == null || profile.exploreProfiles.items.length == 0) {
-//               continueFetch = false;
-//             }
-//             for (const item of profile.exploreProfiles.items) {
-//               dataProfiles[item.ownedBy] = 1;
-//               profilesFetched++;
-//             }
-//           }
-//           console.log(`Lens profiles count: ${profilesFetched}`);
-//         })
-//         .catch((error) => {
-//           throw new Error(error);
-//         });
-//     }
-
-//     return dataProfiles;
-//   }
 
 //   public async *exploreProfilesWithMaxRank(
 //     maxRank: number
@@ -158,103 +106,5 @@ export class LensProviderBigQuery extends BigQueryProvider {
 //     } while (counter < maxRank / 50);
 //   }
 
-//   private async *_getWhoCollectedPublication({
-//     publicationId,
-//   }: PublicationId): AsyncGenerator<Wallet, void, undefined> {
-//     let cursor = "";
-//     let lensCollectors: GetWhoCollectedPublicationType;
-//     do {
-//       lensCollectors = await getWhoCollectedPublicationQuery(
-//         this,
-//         publicationId,
-//         cursor
-//       );
-//       yield* lensCollectors.whoCollectedPublication.items;
-//       cursor = lensCollectors.whoCollectedPublication.pageInfo.next;
-//     } while (lensCollectors.whoCollectedPublication.items.length > 0);
-//   }
-
-//   private async *_getWhoMirroredPublication({
-//     publicationId,
-//   }: PublicationId): AsyncGenerator<ProfileType, void, undefined> {
-//     let cursor = "";
-//     let lensMirrorers: GetWhoMirroredPublicationType;
-//     do {
-//       lensMirrorers = await getWhoMirroredPublicationQuery(
-//         this,
-//         publicationId,
-//         cursor
-//       );
-//       yield* lensMirrorers.profiles.items;
-//       cursor = lensMirrorers.profiles.pageInfo.next;
-//     } while (lensMirrorers.profiles.items.length > 0);
-//   }
-
-//   public async *getProfileWithHandles(
-//     handles: string[]
-//   ): AsyncGenerator<ProfileType, void, undefined> {
-//     for (const handle of handles) {
-//       const profile = await getProfileWithHandleQuery(this, handle);
-//       yield profile.profile;
-//     }
-//   }
-
-  // private async _getDefaultProfileWithEthAddress(
-  //   ethereumAddress: string
-  // ): Promise<ProfileType> {
-  //   const response = await getDefaultProfileWithEthAddressQuery(
-  //     this,
-  //     ethereumAddress
-  //   );
-  //   return response.defaultProfile;
-  // }
-
-  // /**
-  //  * Use this method to resolve a lens profile id from either an ethereum address, a lens profile id, a lens handle, a ens name.
-  //  * @param input A string from either a ethereum address, a lens profile id, a lens handle, a ens name.
-  //  * @returns The lens profile id as a string.
-  //  */
-  // public async _getProfileIdFromAnySources(input: string): Promise<string> {
-  //   try {
-  //     // Check if input is a valid eth address
-  //     if (input.match(/^0x[a-fA-F0-9]{40}$/g)) {
-  //       const profile = await this._getDefaultProfileWithEthAddress(input);
-  //       if (profile?.id) {
-  //         return profile.id;
-  //       } else {
-  //         throw new Error("No profile found for this ethereum address");
-  //       }
-  //     }
-  //     // Check if input is a valid lens profile id
-  //     if (input.match(/^0x[a-fA-F0-9]{0,39}$/g)) {
-  //       return input;
-  //     }
-  //     // Check if input is a valid lens handle
-  //     if (input.includes(".lens")) {
-  //       const response = await getProfileWithHandleQuery(this, input);
-  //       if (response?.profile?.id) {
-  //         return response.profile.id;
-  //       } else {
-  //         throw new Error("No profile found for this Lens handle");
-  //       }
-  //     }
-  //     // Check if input is a valid ens name
-  //     if (input.includes(".eth")) {
-  //       const ensProvider = new EnsProvider();
-  //       const ethAddress = await ensProvider.resolveEnsFromJsonRpc(input);
-  //       const profile = await this._getDefaultProfileWithEthAddress(ethAddress);
-
-  //       if (profile?.id) {
-  //         return profile.id;
-  //       } else {
-  //         throw new Error("No profile found for this ENS");
-  //       }
-  //     } else {
-  //       throw new Error("Invalid input format");
-  //     }
-  //   } catch (err) {
-  //     throw new Error("Invalid input");
-  //   }
-  // }
 }
 

--- a/group-generators/helpers/data-providers/lens-bigquery/index.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/index.ts
@@ -70,19 +70,16 @@ export class LensProviderBigQuery extends BigQueryProvider {
     return count;
   }
 
-  public async getProfilesRank(rankingCriteria: RankingCriteria): Promise<FetchedData> {
+  public async getPublicationCommenters(publication: Publication): Promise<FetchedData> {
     let dataProfiles: FetchedData = {};
-    const query = getProfilesRankQuery(rankingCriteria);
+    const query = getPublicationCommentersQuery(publication);
     dataProfiles = await this.fetchAccounts(query);
     return dataProfiles;
   }
 
-  public async getProfilesRankCount(rankingCriteria: RankingCriteria): Promise<number> {
-    const query = getProfilesRankCountQuery(rankingCriteria);
+  public async getPublicationCommentersCount(publication: Publication): Promise<number> {
+    const query = getPublicationCommentersCountQuery(publication);
     const count = await this.fetchCount(query);
-    if(count) {
-      return rankingCriteria.rank;
-    }
     return count;
   }
 
@@ -99,31 +96,38 @@ export class LensProviderBigQuery extends BigQueryProvider {
     return count;
   }
 
-  public async getPublicationCommenters(publication: Publication): Promise<FetchedData> {
-    let dataProfiles: FetchedData = {};
-    const query = getPublicationCommentersQuery(publication);
-    dataProfiles = await this.fetchAccounts(query);
-    return dataProfiles;
-  }
-
-  public async getPublicationCommentersCount(publication: Publication): Promise<number> {
-    const query = getPublicationCommentersCountQuery(publication);
-    const count = await this.fetchCount(query);
-    return count;
-  }
-
   public async getHashtagMentioners(hashtag: Hashtag): Promise<FetchedData> {
     let dataProfiles: FetchedData = {};
-    const formatedHashtag: Hashtag = {hashtag: hashtag.hashtag.toLowerCase()};
-    const query = getHashtagMentionersQuery(formatedHashtag);
+    if (hashtag.hashtag.charAt(0) === "#") {
+      hashtag.hashtag = hashtag.hashtag.slice(1);
+    }  
+    const query = getHashtagMentionersQuery(hashtag);
     dataProfiles = await this.fetchAccounts(query);
     return dataProfiles;
   }
 
   public async getHashtagMentionersCount(hashtag: Hashtag): Promise<number> {
-    const formatedHashtag: Hashtag = {hashtag: hashtag.hashtag.toLowerCase()};
-    const query = getHashtagMentionersCountQuery(formatedHashtag);
+    if (hashtag.hashtag.charAt(0) === "#") {
+      hashtag.hashtag = hashtag.hashtag.slice(1);
+    }  
+    const query = getHashtagMentionersCountQuery(hashtag);
     const count = await this.fetchCount(query);
+    return count;
+  }
+
+  public async getProfilesRank(rankingCriteria: RankingCriteria): Promise<FetchedData> {
+    let dataProfiles: FetchedData = {};
+    const query = getProfilesRankQuery(rankingCriteria);
+    dataProfiles = await this.fetchAccounts(query);
+    return dataProfiles;
+  }
+
+  public async getProfilesRankCount(rankingCriteria: RankingCriteria): Promise<number> {
+    const query = getProfilesRankCountQuery(rankingCriteria);
+    const count = await this.fetchCount(query);
+    if(count) {
+      return rankingCriteria.rank;
+    }
     return count;
   }
 

--- a/group-generators/helpers/data-providers/lens-bigquery/index.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/index.ts
@@ -9,6 +9,8 @@ import {
   getProfilesRankCountQuery,
   getPublicationReactorsQuery,
   getPublicationReactorsCountQuery,
+  getWhoCommentedPublicationQuery,
+  getWhoCommentedPublicationCountQuery,
 } from "./queries";
 import { PublicationReaction } from "./types";
 import { BigQueryProvider, SupportedNetwork } from "@group-generators/helpers/data-providers/big-query";
@@ -99,6 +101,19 @@ export class LensProviderBigQuery extends BigQueryProvider {
 
   public async getPublicationReactorsCount(publicationReaction: PublicationReaction): Promise<number> {
     const query = getPublicationReactorsCountQuery(publicationReaction);
+    const count = await this.fetchCount(query);
+    return count;
+  }
+
+  public async getWhoCommentedPublication(publicationId: PublicationId): Promise<FetchedData> {
+    let dataProfiles: FetchedData = {};
+    const query = getWhoCommentedPublicationQuery(publicationId);
+    dataProfiles = await this.fetch(query);
+    return dataProfiles;
+  }
+
+  public async getWhoCommentedPublicationCount(publicationId: PublicationId): Promise<number> {
+    const query = getWhoCommentedPublicationCountQuery(publicationId);
     const count = await this.fetchCount(query);
     return count;
   }

--- a/group-generators/helpers/data-providers/lens-bigquery/index.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/index.ts
@@ -1,34 +1,25 @@
 import {
   getFollowersCountQuery,
   getFollowersQuery,
-  getWhoCollectedPublicationQuery,
-  getWhoCollectedPublicationCountQuery,
-  getWhoMirroredPublicationQuery,
-  getWhoMirroredPublicationCountQuery,
   getProfilesRankQuery,
   getProfilesRankCountQuery,
-  getWhoReactedToPublicationQuery,
-  getWhoReactedToPublicationCountQuery,
-  getWhoCommentedPublicationQuery,
-  getWhoCommentedPublicationCountQuery,
   getHashtagMentionersQuery,
   getHashtagMentionersCountQuery,
+  getPublicationCollectorsQuery,
+  getPublicationCollectorsCountQuery,
+  getPublicationMirrorersQuery,
+  getPublicationMirrorersCountQuery,
+  getPublicationReactorsQuery,
+  getPublicationReactorsCountQuery,
+  getPublicationCommentersQuery,
+  getPublicationCommentersCountQuery,
 } from "./queries";
 import { Hashtag, PublicationReaction } from "./types";
 import { BigQueryProvider, SupportedNetwork } from "@group-generators/helpers/data-providers/big-query";
-// import { EnsProvider } from "@group-generators/helpers/data-providers/ens";
 import {
-  // ExploreProfileType,
-  // FollowerType,
-  // GetFollowersType,
-  // GetWhoCollectedPublicationType,
-  // GetWhoMirroredPublicationType,
-  // ProfileType,
   ProfileId,
   PublicationId,
-  // Wallet,
 } from "@group-generators/helpers/data-providers/lens/types";
-// import { retryRequest } from "@group-generators/helpers/data-providers/utils/utils";
 import { FetchedData } from "topics/group";
 
 export class LensProviderBigQuery extends BigQueryProvider {
@@ -52,28 +43,28 @@ export class LensProviderBigQuery extends BigQueryProvider {
     return count;
   }
 
-  public async getWhoCollectedPublication(publication: PublicationId): Promise<FetchedData> {
+  public async getPublicationCollectors(publication: PublicationId): Promise<FetchedData> {
     let dataProfiles: FetchedData = {};
-    const query = getWhoCollectedPublicationQuery(publication);
+    const query = getPublicationCollectorsQuery(publication);
     dataProfiles = await this.fetch(query);
     return dataProfiles;
   }
 
-  public async getWhoCollectedPublicationCount(publication: PublicationId): Promise<number> {
-    const query = getWhoCollectedPublicationCountQuery(publication);
+  public async getPublicationCollectorsCount(publication: PublicationId): Promise<number> {
+    const query = getPublicationCollectorsCountQuery(publication);
     const count = await this.fetchCount(query);
     return count;
   }
 
-  public async getWhoMirroredPublication(publication: PublicationId): Promise<FetchedData> {
+  public async getPublicationMirrorers(publication: PublicationId): Promise<FetchedData> {
     let dataProfiles: FetchedData = {};
-    const query = getWhoMirroredPublicationQuery(publication);
+    const query = getPublicationMirrorersQuery(publication);
     dataProfiles = await this.fetch(query);
     return dataProfiles;
   }
 
-  public async getWhoMirroredPublicationCount(publication: PublicationId): Promise<number> {
-    const query = getWhoMirroredPublicationCountQuery(publication);
+  public async getPublicationMirrorersCount(publication: PublicationId): Promise<number> {
+    const query = getPublicationMirrorersCountQuery(publication);
     const count = await this.fetchCount(query);
     return count;
   }
@@ -94,28 +85,28 @@ export class LensProviderBigQuery extends BigQueryProvider {
     return count;
   }
 
-  public async getWhoReactedToPublication(publicationReaction: PublicationReaction): Promise<FetchedData> {
+  public async getPublicationReactors(publicationReaction: PublicationReaction): Promise<FetchedData> {
     let dataProfiles: FetchedData = {};
-    const query = getWhoReactedToPublicationQuery(publicationReaction);
+    const query = getPublicationReactorsQuery(publicationReaction);
     dataProfiles = await this.fetch(query);
     return dataProfiles;
   }
 
-  public async getWhoReactedToPublicationCount(publicationReaction: PublicationReaction): Promise<number> {
-    const query = getWhoReactedToPublicationCountQuery(publicationReaction);
+  public async getPublicationReactorsCount(publicationReaction: PublicationReaction): Promise<number> {
+    const query = getPublicationReactorsCountQuery(publicationReaction);
     const count = await this.fetchCount(query);
     return count;
   }
 
-  public async getWhoCommentedPublication(publicationId: PublicationId): Promise<FetchedData> {
+  public async getPublicationCommenters(publicationId: PublicationId): Promise<FetchedData> {
     let dataProfiles: FetchedData = {};
-    const query = getWhoCommentedPublicationQuery(publicationId);
+    const query = getPublicationCommentersQuery(publicationId);
     dataProfiles = await this.fetch(query);
     return dataProfiles;
   }
 
-  public async getWhoCommentedPublicationCount(publicationId: PublicationId): Promise<number> {
-    const query = getWhoCommentedPublicationCountQuery(publicationId);
+  public async getPublicationCommentersCount(publicationId: PublicationId): Promise<number> {
+    const query = getPublicationCommentersCountQuery(publicationId);
     const count = await this.fetchCount(query);
     return count;
   }

--- a/group-generators/helpers/data-providers/lens-bigquery/interface-schema.json
+++ b/group-generators/helpers/data-providers/lens-bigquery/interface-schema.json
@@ -1,0 +1,119 @@
+{
+  "name": "Lens",
+  "iconUrl": "",
+  "providerClassName": "LensProvider",
+  "functions": [
+    {
+      "name": "Get followers of",
+      "functionName": "getFollowers",
+      "countFunctionName": "getFollowersCount",
+      "description": "Returns all followers for a specific Lens profile",
+      "args": [
+        {
+          "name": "profile identifier",
+          "argName": "profileId",
+          "type": "string",
+          "example": "sismo.lens | 0x26e5 | sismo.eth | 0xB0A179C459484885D1875009110F3cE3064867B9",
+          "description": "A Lens profile identifier that could be either of a Lens handle, a Lens profile Id, an ENS or an Ethereum address"
+        }
+      ]
+    },
+    {
+      "name": "Get collectors of",
+      "functionName": "getPublicationCollectors",
+      "countFunctionName": "getPublicationCollectorsCount",
+      "description": "Returns all collectors of a specific publication",
+      "args": [
+        {
+          "name": "publication identifier",
+          "argName": "publicationId",
+          "type": "string",
+          "example": "0x26e5-0x03",
+          "description": "A Lens publication identifier in the following format {profileId}-{publicationId}. https://docs.lens.xyz/docs/get-publication"
+        }
+      ]
+    },
+    {
+      "name": "Get mirrorers of",
+      "functionName": "getPublicationMirrorers",
+      "countFunctionName": "getPublicationMirrorersCount",
+      "description": "Returns all profiles who have mirrored a specific publication",
+      "args": [
+        {
+          "name": "publication identifier",
+          "argName": "publicationId",
+          "type": "string",
+          "example": "0x26e5-0x03",
+          "description": "A Lens publication identifier in the following format {profileId}-{publicationId}. https://docs.lens.xyz/docs/get-publication"
+        }
+      ]
+    },
+    {
+      "name": "Get commenters of",
+      "functionName": "getPublicationCommenters",
+      "countFunctionName": "getPublicationCommentersCount",
+      "description": "Returns all profiles who have commented a specific publication",
+      "args": [
+        {
+          "name": "publication identifier",
+          "argName": "publicationId",
+          "type": "string",
+          "example": "0x26e5-0x03",
+          "description": "A Lens publication identifier in the following format {profileId}-{publicationId}. https://docs.lens.xyz/docs/get-publication"
+        }
+      ]
+    },
+    {
+      "name": "Get reactors of",
+      "functionName": "getPublicationReactors",
+      "countFunctionName": "getPublicationReactorsCount",
+      "description": "Returns all profiles who have reacted to a specific publication",
+      "args": [
+        {
+          "name": "publication identifier",
+          "argName": "publicationId",
+          "type": "string",
+          "example": "0x26e5-0x03",
+          "description": "A Lens publication identifier in the following format {profileId}-{publicationId}. https://docs.lens.xyz/docs/get-publication"
+        },
+        {
+          "name": "reaction",
+          "argName": "reaction",
+          "type": "string",
+          "example": "UPVOTE",
+          "description": "A Lens publication reaction can be: UPVOTE or DOWNVOTE https://docs.lens.xyz/docs/add-reaction"
+        }
+      ]
+    },
+    {
+      "name": "Get mentioners of",
+      "functionName": "getHashtagMentioners",
+      "countFunctionName": "getHashtagMentionersCount",
+      "description": "Returns all profiles who have created lens publication with the corresponding hashtag",
+      "args": [
+        {
+          "name": "hashtag",
+          "argName": "hashtag",
+          "type": "string",
+          "example": "DeFi",
+          "description": "The hashtag to search for"
+        }
+      ]
+    },
+    {
+      "name": "Get profile ranked",
+      "functionName": "getProfilesRanking",
+      "countFunctionName": "getProfilesRankingCount",
+      "description": "Returns the first profiles who have been created on lens",
+      "args": [
+        {
+          "name": "rank",
+          "argName": "rank",
+          "type": "number",
+          "example": "50",
+          "description": "The number of firsts profiles to return"
+        }
+      ]
+    }
+  ]
+}

--- a/group-generators/helpers/data-providers/lens-bigquery/interface-schema.json
+++ b/group-generators/helpers/data-providers/lens-bigquery/interface-schema.json
@@ -1,13 +1,13 @@
 {
   "name": "Lens",
   "iconUrl": "",
-  "providerClassName": "LensProvider",
+  "providerClassName": "LensBigQueryProvider",
   "functions": [
     {
       "name": "Get followers of",
       "functionName": "getFollowers",
       "countFunctionName": "getFollowersCount",
-      "description": "Returns all followers for a specific Lens profile",
+      "description": "Returns all followers for a specific Lens profile. The values of the accounts represent their chronological order of following.",
       "args": [
         {
           "name": "profile identifier",
@@ -22,7 +22,7 @@
       "name": "Get collectors of",
       "functionName": "getPublicationCollectors",
       "countFunctionName": "getPublicationCollectorsCount",
-      "description": "Returns all collectors of a specific publication",
+      "description": "Returns all collectors of a specific publication. The values of the accounts represent their chronological order of collection.",
       "args": [
         {
           "name": "publication identifier",
@@ -37,7 +37,7 @@
       "name": "Get mirrorers of",
       "functionName": "getPublicationMirrorers",
       "countFunctionName": "getPublicationMirrorersCount",
-      "description": "Returns all profiles who have mirrored a specific publication",
+      "description": "Returns all profiles who have mirrored a specific publication. The values of the accounts represent their chronological order of mirroring.",
       "args": [
         {
           "name": "publication identifier",
@@ -52,7 +52,7 @@
       "name": "Get commenters of",
       "functionName": "getPublicationCommenters",
       "countFunctionName": "getPublicationCommentersCount",
-      "description": "Returns all profiles who have commented a specific publication",
+      "description": "Returns all profiles who have commented a specific publication. The values of the accounts represent the number of comments posted.",
       "args": [
         {
           "name": "publication identifier",
@@ -67,7 +67,7 @@
       "name": "Get reactors of",
       "functionName": "getPublicationReactors",
       "countFunctionName": "getPublicationReactorsCount",
-      "description": "Returns all profiles who have reacted to a specific publication",
+      "description": "Returns all profiles who have reacted to a specific publication. The values of the accounts represent their chronological order of reaction.",
       "args": [
         {
           "name": "publication identifier",
@@ -89,7 +89,7 @@
       "name": "Get mentioners of",
       "functionName": "getHashtagMentioners",
       "countFunctionName": "getHashtagMentionersCount",
-      "description": "Returns all profiles who have created lens publication with the corresponding hashtag",
+      "description": "Returns all profiles who have created lens publication with the corresponding hashtag. Account values represent the number of publications posted containing the hashtag.",
       "args": [
         {
           "name": "hashtag",
@@ -97,21 +97,6 @@
           "type": "string",
           "example": "DeFi",
           "description": "The hashtag to search for"
-        }
-      ]
-    },
-    {
-      "name": "Get profile ranked",
-      "functionName": "getProfilesRanking",
-      "countFunctionName": "getProfilesRankingCount",
-      "description": "Returns the first profiles who have been created on lens",
-      "args": [
-        {
-          "name": "rank",
-          "argName": "rank",
-          "type": "number",
-          "example": "50",
-          "description": "The number of firsts profiles to return"
         }
       ]
     }

--- a/group-generators/helpers/data-providers/lens-bigquery/queries.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/queries.ts
@@ -39,9 +39,9 @@ export const getPublicationCollectorsQuery = ({
 export const getPublicationCollectorsCountQuery = ({
   publicationId
 }: Publication) => {
-  return `SELECT COUNT(DISTINCT owner_address)
-  FROM \`lens-public-data.polygon.public_collect_post_nft_ownership\`
-  WHERE post_id = "${publicationId}"`;
+    return `SELECT COUNT(DISTINCT owner_address)
+    FROM \`lens-public-data.polygon.public_collect_post_nft_ownership\`
+    WHERE post_id = "${publicationId}"`;
 };
 
 export const getPublicationMirrorersQuery = ({

--- a/group-generators/helpers/data-providers/lens-bigquery/queries.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/queries.ts
@@ -53,7 +53,7 @@ export const getPublicationMirrorersQuery = ({
       SELECT profile_id
       FROM \`lens-public-data.polygon.public_profile_post\`
       WHERE is_related_to_post = "${publicationId}"
-    );`
+    )`;
 };
 
 export const getPublicationMirrorersCountQuery = ({
@@ -65,7 +65,7 @@ export const getPublicationMirrorersCountQuery = ({
       SELECT profile_id
       FROM \`lens-public-data.polygon.public_profile_post\`
       WHERE is_related_to_post = "${publicationId}"
-    );`
+    )`;
 };
 
 export const getPublicationCommentersQuery = ({
@@ -75,16 +75,20 @@ export const getPublicationCommentersQuery = ({
     FROM \`lens-public-data.polygon.public_profile\` profile
     JOIN \`lens-public-data.polygon.public_post_comment\` post ON profile.profile_id = post.comment_by_profile_id
     WHERE post.post_id = "${publicationId}"
-    GROUP BY profile.owned_by;`
+    GROUP BY profile.owned_by`;
 };
 
 export const getPublicationCommentersCountQuery = ({
   publicationId
 }: Publication) => {
-    return `SELECT COUNT(DISTINCT profile.profile_id)
-    FROM \`lens-public-data.polygon.public_profile\` profile
-    JOIN \`lens-public-data.polygon.public_post_comment\` post ON profile.profile_id = post.comment_by_profile_id
-    WHERE post.post_id = "${publicationId}"`
+    return `SELECT COUNT(*)
+    FROM (
+        SELECT profile.owned_by AS address, COUNT(post.comment_by_profile_id) AS value
+        FROM \`lens-public-data.polygon.public_profile\` profile
+        JOIN \`lens-public-data.polygon.public_post_comment\` post ON profile.profile_id = post.comment_by_profile_id
+        WHERE post.post_id = "${publicationId}"
+        GROUP BY profile.owned_by
+    )`;
 };
 
 export const getPublicationReactorsQuery = ({
@@ -97,7 +101,7 @@ export const getPublicationReactorsQuery = ({
       SELECT actioned_by_profile_id
       FROM \`lens-public-data.polygon.public_publication_reaction_records\`
       WHERE publication_id = "${publicationId}" AND reaction = "${reaction}" AND has_undone is FALSE
-    )`
+    )`;
 };
 
 export const getPublicationReactorsCountQuery = ({
@@ -106,7 +110,7 @@ export const getPublicationReactorsCountQuery = ({
 }: PublicationReaction) => {
     return `SELECT COUNT(actioned_by_profile_id)
     FROM \`lens-public-data.polygon.public_publication_reaction_records\`
-    WHERE publication_id = "${publicationId}" AND reaction = "${reaction}" AND has_undone is FALSE`
+    WHERE publication_id = "${publicationId}" AND reaction = "${reaction}" AND has_undone is FALSE`;
 };
 
 export const getHashtagMentionersQuery = ({
@@ -117,7 +121,7 @@ export const getHashtagMentionersQuery = ({
     JOIN \`lens-public-data.polygon.public_profile_post\` post ON profile.profile_id = post.profile_id
     JOIN \`lens-public-data.polygon.public_hashtag\` hashtag ON post.post_id = hashtag.post_id
     WHERE LOWER(hashtag.hashtag) = LOWER("${hashtag}")
-    GROUP BY profile.owned_by;`
+    GROUP BY profile.owned_by`;
 };
 
 export const getHashtagMentionersCountQuery = ({
@@ -127,5 +131,5 @@ export const getHashtagMentionersCountQuery = ({
     FROM \`lens-public-data.polygon.public_profile\` profile
     JOIN \`lens-public-data.polygon.public_profile_post\` post ON profile.profile_id = post.profile_id
     JOIN \`lens-public-data.polygon.public_hashtag\` hashtag ON post.post_id = hashtag.post_id
-    WHERE LOWER(hashtag.hashtag) = LOWER("${hashtag}")`
+    WHERE LOWER(hashtag.hashtag) = LOWER("${hashtag}")`;
 };

--- a/group-generators/helpers/data-providers/lens-bigquery/queries.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/queries.ts
@@ -1,5 +1,7 @@
+import { PublicationReaction } from "./types";
 import {
-  ProfileId, PublicationId,
+  ProfileId, 
+  PublicationId,
 } from "@group-generators/helpers/data-providers/lens/types";
 
 
@@ -68,4 +70,26 @@ export const getProfilesRankQuery = (rank: number) => {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const getProfilesRankCountQuery = (rank: number) => {
   return `SELECT COUNT(*) FROM \`lens-public-data.polygon.public_profile\``;
+};
+
+export const getPublicationReactorsQuery = ({
+  publicationId,
+  reaction
+}: PublicationReaction) => {
+    return `SELECT owned_by AS address, ROW_NUMBER() OVER(ORDER BY block_timestamp ASC) as value
+    FROM \`lens-public-data.polygon.public_profile\`
+    WHERE profile_id IN (
+      SELECT actioned_by_profile_id
+      FROM \`lens-public-data.polygon.public_publication_reaction_records\`
+      WHERE publication_id = "${publicationId}" AND reaction = "${reaction}" AND has_undone is FALSE
+    )`
+};
+
+export const getPublicationReactorsCountQuery = ({
+  publicationId,
+  reaction
+}: PublicationReaction) => {
+    return `SELECT COUNT(actioned_by_profile_id)
+    FROM \`lens-public-data.polygon.public_publication_reaction_records\`
+    WHERE publication_id = "${publicationId}" AND reaction = "${reaction}" AND has_undone is FALSE`
 };

--- a/group-generators/helpers/data-providers/lens-bigquery/queries.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/queries.ts
@@ -1,0 +1,20 @@
+import {
+  ProfileId,
+} from "@group-generators/helpers/data-providers/lens/types";
+
+
+export const getFollowersQuery = ({
+  profileId
+}: ProfileId) => {
+    return `SELECT address, ROW_NUMBER() OVER(ORDER BY block_timestamp ASC) as value 
+    FROM \`lens-public-data.polygon.public_follower\` 
+    WHERE follow_profile_id = "${profileId}"`;
+};
+
+export const getFollowersCountQuery = ({
+  profileId
+}: ProfileId) => {
+    return `SELECT count(*) 
+    FROM \`lens-public-data.polygon.public_follower\` 
+    WHERE follow_profile_id = "${profileId}"`;
+};

--- a/group-generators/helpers/data-providers/lens-bigquery/queries.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/queries.ts
@@ -61,39 +61,6 @@ export const getWhoMirroredPublicationCountQuery = ({
     );`
 };
 
-export const getProfilesRankQuery = (rank: number) => {
-    return `SELECT owned_by as address, ROW_NUMBER() OVER(ORDER BY block_timestamp ASC) as value
-    FROM \`lens-public-data.polygon.public_profile\`
-    ORDER BY block_timestamp ASC LIMIT ${rank}`;
-};
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const getProfilesRankCountQuery = (rank: number) => {
-  return `SELECT COUNT(*) FROM \`lens-public-data.polygon.public_profile\``;
-};
-
-export const getPublicationReactorsQuery = ({
-  publicationId,
-  reaction
-}: PublicationReaction) => {
-    return `SELECT owned_by AS address, ROW_NUMBER() OVER(ORDER BY block_timestamp ASC) as value
-    FROM \`lens-public-data.polygon.public_profile\`
-    WHERE profile_id IN (
-      SELECT actioned_by_profile_id
-      FROM \`lens-public-data.polygon.public_publication_reaction_records\`
-      WHERE publication_id = "${publicationId}" AND reaction = "${reaction}" AND has_undone is FALSE
-    )`
-};
-
-export const getPublicationReactorsCountQuery = ({
-  publicationId,
-  reaction
-}: PublicationReaction) => {
-    return `SELECT COUNT(actioned_by_profile_id)
-    FROM \`lens-public-data.polygon.public_publication_reaction_records\`
-    WHERE publication_id = "${publicationId}" AND reaction = "${reaction}" AND has_undone is FALSE`
-};
-
 export const getWhoCommentedPublicationQuery = ({
   publicationId
 }: PublicationId) => {
@@ -108,4 +75,37 @@ export const getWhoCommentedPublicationCountQuery = ({
   publicationId
 }: PublicationId) => {
     return `SELECT COUNT(DISTINCT comment_by_profile_id) FROM \`lens-public-data.polygon.public_post_comment\` WHERE post_id = "${publicationId}"`
+};
+
+export const getWhoReactedToPublicationQuery = ({
+  publicationId,
+  reaction
+}: PublicationReaction) => {
+    return `SELECT owned_by AS address, ROW_NUMBER() OVER(ORDER BY block_timestamp ASC) as value
+    FROM \`lens-public-data.polygon.public_profile\`
+    WHERE profile_id IN (
+      SELECT actioned_by_profile_id
+      FROM \`lens-public-data.polygon.public_publication_reaction_records\`
+      WHERE publication_id = "${publicationId}" AND reaction = "${reaction}" AND has_undone is FALSE
+    )`
+};
+
+export const getWhoReactedToPublicationCountQuery = ({
+  publicationId,
+  reaction
+}: PublicationReaction) => {
+    return `SELECT COUNT(actioned_by_profile_id)
+    FROM \`lens-public-data.polygon.public_publication_reaction_records\`
+    WHERE publication_id = "${publicationId}" AND reaction = "${reaction}" AND has_undone is FALSE`
+};
+
+export const getProfilesRankQuery = (rank: number) => {
+    return `SELECT owned_by as address, ROW_NUMBER() OVER(ORDER BY block_timestamp ASC) as value
+    FROM \`lens-public-data.polygon.public_profile\`
+    ORDER BY block_timestamp ASC LIMIT ${rank}`;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const getProfilesRankCountQuery = (rank: number) => {
+  return `SELECT COUNT(*) FROM \`lens-public-data.polygon.public_profile\``;
 };

--- a/group-generators/helpers/data-providers/lens-bigquery/queries.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/queries.ts
@@ -20,6 +20,18 @@ export const getFollowersCountQuery = ({
     WHERE follow_profile_id = "${profileId}"`;
 };
 
+export const getProfileFromAddressQuery = (address: string) => {
+  return `SELECT profile_id
+  FROM \`lens-public-data.polygon.public_profile\`
+  WHERE LOWER(owned_by) = LOWER("${address}")`;
+};
+
+export const getProfileFromHandleQuery = (handle: string) => {
+  return `SELECT profile_id
+  FROM \`lens-public-data.polygon.public_profile\`
+  WHERE LOWER(handle) = LOWER("${handle}")`;
+};
+
 export const getPublicationCollectorsQuery = ({
   publicationId
 }: PublicationId) => {

--- a/group-generators/helpers/data-providers/lens-bigquery/queries.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/queries.ts
@@ -1,12 +1,8 @@
-import { Hashtag, PublicationReaction } from "./types";
-import {
-  ProfileId, 
-  PublicationId,
-} from "@group-generators/helpers/data-providers/lens/types";
+import { Hashtag, Profile, Publication, PublicationReaction, RankingCriteria } from "./types";
 
 export const getFollowersQuery = ({
   profileId
-}: ProfileId) => {
+}: Profile) => {
     return `SELECT address, ROW_NUMBER() OVER(ORDER BY block_timestamp ASC) as value 
     FROM \`lens-public-data.polygon.public_follower\` 
     WHERE follow_profile_id = "${profileId}"`;
@@ -14,7 +10,7 @@ export const getFollowersQuery = ({
 
 export const getFollowersCountQuery = ({
   profileId
-}: ProfileId) => {
+}: Profile) => {
     return `SELECT count(*) 
     FROM \`lens-public-data.polygon.public_follower\` 
     WHERE follow_profile_id = "${profileId}"`;
@@ -34,7 +30,7 @@ export const getProfileFromHandleQuery = (handle: string) => {
 
 export const getPublicationCollectorsQuery = ({
   publicationId
-}: PublicationId) => {
+}: Publication) => {
     return `SELECT owner_address as address, ROW_NUMBER() OVER(ORDER BY block_timestamp ASC) as value
     FROM \`lens-public-data.polygon.public_collect_post_nft_ownership\`
     WHERE post_id = "${publicationId}"`;
@@ -42,7 +38,7 @@ export const getPublicationCollectorsQuery = ({
 
 export const getPublicationCollectorsCountQuery = ({
   publicationId
-}: PublicationId) => {
+}: Publication) => {
   return `SELECT COUNT(DISTINCT owner_address)
   FROM \`lens-public-data.polygon.public_collect_post_nft_ownership\`
   WHERE post_id = "${publicationId}"`;
@@ -50,7 +46,7 @@ export const getPublicationCollectorsCountQuery = ({
 
 export const getPublicationMirrorersQuery = ({
   publicationId
-}: PublicationId) => {
+}: Publication) => {
     return `SELECT owned_by AS address, ROW_NUMBER() OVER(ORDER BY block_timestamp ASC) as value
     FROM \`lens-public-data.polygon.public_profile\`
     WHERE profile_id IN (
@@ -62,7 +58,7 @@ export const getPublicationMirrorersQuery = ({
 
 export const getPublicationMirrorersCountQuery = ({
   publicationId
-}: PublicationId) => {
+}: Publication) => {
     return `SELECT COUNT(DISTINCT owned_by)
     FROM \`lens-public-data.polygon.public_profile\`
     WHERE profile_id IN (
@@ -74,7 +70,7 @@ export const getPublicationMirrorersCountQuery = ({
 
 export const getPublicationCommentersQuery = ({
   publicationId
-}: PublicationId) => {
+}: Publication) => {
     return `SELECT profile.owned_by AS address, COUNT(post.comment_by_profile_id) AS value
     FROM \`lens-public-data.polygon.public_profile\` profile
     JOIN \`lens-public-data.polygon.public_post_comment\` post ON profile.profile_id = post.comment_by_profile_id
@@ -84,7 +80,7 @@ export const getPublicationCommentersQuery = ({
 
 export const getPublicationCommentersCountQuery = ({
   publicationId
-}: PublicationId) => {
+}: Publication) => {
     return `SELECT COUNT(DISTINCT profile.profile_id)
     FROM \`lens-public-data.polygon.public_profile\` profile
     JOIN \`lens-public-data.polygon.public_post_comment\` post ON profile.profile_id = post.comment_by_profile_id
@@ -113,14 +109,18 @@ export const getPublicationReactorsCountQuery = ({
     WHERE publication_id = "${publicationId}" AND reaction = "${reaction}" AND has_undone is FALSE`
 };
 
-export const getProfilesRankQuery = (rank: number) => {
+export const getProfilesRankQuery = ({
+  rank
+}: RankingCriteria) => {
     return `SELECT owned_by as address, ROW_NUMBER() OVER(ORDER BY block_timestamp ASC) as value
     FROM \`lens-public-data.polygon.public_profile\`
     ORDER BY block_timestamp ASC LIMIT ${rank}`;
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export const getProfilesRankCountQuery = (rank: number) => {
+export const getProfilesRankCountQuery = ({
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  rank
+}: RankingCriteria) => {
   return `SELECT COUNT(*) FROM \`lens-public-data.polygon.public_profile\``;
 };
 

--- a/group-generators/helpers/data-providers/lens-bigquery/queries.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/queries.ts
@@ -1,9 +1,8 @@
-import { PublicationReaction } from "./types";
+import { Hashtag, PublicationReaction } from "./types";
 import {
   ProfileId, 
   PublicationId,
 } from "@group-generators/helpers/data-providers/lens/types";
-
 
 export const getFollowersQuery = ({
   profileId
@@ -74,7 +73,10 @@ export const getWhoCommentedPublicationQuery = ({
 export const getWhoCommentedPublicationCountQuery = ({
   publicationId
 }: PublicationId) => {
-    return `SELECT COUNT(DISTINCT comment_by_profile_id) FROM \`lens-public-data.polygon.public_post_comment\` WHERE post_id = "${publicationId}"`
+    return `SELECT COUNT(DISTINCT profile.profile_id)
+    FROM \`lens-public-data.polygon.public_profile\` profile
+    JOIN \`lens-public-data.polygon.public_post_comment\` post ON profile.profile_id = post.comment_by_profile_id
+    WHERE post.post_id = "${publicationId}"`
 };
 
 export const getWhoReactedToPublicationQuery = ({
@@ -108,4 +110,25 @@ export const getProfilesRankQuery = (rank: number) => {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const getProfilesRankCountQuery = (rank: number) => {
   return `SELECT COUNT(*) FROM \`lens-public-data.polygon.public_profile\``;
+};
+
+export const getHashtagMentionersQuery = ({
+  hashtag
+}: Hashtag) => {
+    return `SELECT profile.owned_by AS address, COUNT(post.profile_id) AS value
+    FROM \`lens-public-data.polygon.public_profile\` profile
+    JOIN \`lens-public-data.polygon.public_profile_post\` post ON profile.profile_id = post.profile_id
+    JOIN \`lens-public-data.polygon.public_hashtag\` hashtag ON post.post_id = hashtag.post_id
+    WHERE hashtag.hashtag = "${hashtag}"
+    GROUP BY profile.owned_by;`
+};
+
+export const getHashtagMentionersCountQuery = ({
+  hashtag
+}: Hashtag) => {
+    return `SELECT COUNT(DISTINCT profile.owned_by)
+    FROM \`lens-public-data.polygon.public_profile\` profile
+    JOIN \`lens-public-data.polygon.public_profile_post\` post ON profile.profile_id = post.profile_id
+    JOIN \`lens-public-data.polygon.public_hashtag\` hashtag ON post.post_id = hashtag.post_id
+    WHERE hashtag.hashtag = "${hashtag}"`
 };

--- a/group-generators/helpers/data-providers/lens-bigquery/queries.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/queries.ts
@@ -19,7 +19,7 @@ export const getFollowersCountQuery = ({
     WHERE follow_profile_id = "${profileId}"`;
 };
 
-export const getWhoCollectedPublicationsQuery = ({
+export const getWhoCollectedPublicationQuery = ({
   publicationId
 }: PublicationId) => {
     return `SELECT owner_address as address, ROW_NUMBER() OVER(ORDER BY block_timestamp ASC) as value
@@ -27,10 +27,34 @@ export const getWhoCollectedPublicationsQuery = ({
     WHERE post_id = "${publicationId}"`;
 };
 
-export const getWhoCollectedPublicationsCountQuery = ({
+export const getWhoCollectedPublicationCountQuery = ({
   publicationId
 }: PublicationId) => {
   return `SELECT COUNT(DISTINCT owner_address)
   FROM \`lens-public-data.polygon.public_collect_post_nft_ownership\`
   WHERE post_id = "${publicationId}"`;
+};
+
+export const getWhoMirroredPublicationQuery = ({
+  publicationId
+}: PublicationId) => {
+    return `SELECT owned_by AS address, ROW_NUMBER() OVER(ORDER BY block_timestamp ASC) as value
+    FROM \`lens-public-data.polygon.public_profile\`
+    WHERE profile_id IN (
+      SELECT profile_id
+      FROM \`lens-public-data.polygon.public_profile_post\`
+      WHERE is_related_to_post = "${publicationId}"
+    );`
+};
+
+export const getWhoMirroredPublicationCountQuery = ({
+  publicationId
+}: PublicationId) => {
+    return `SELECT COUNT(DISTINCT owned_by)
+    FROM \`lens-public-data.polygon.public_profile\`
+    WHERE profile_id IN (
+      SELECT profile_id
+      FROM \`lens-public-data.polygon.public_profile_post\`
+      WHERE is_related_to_post = "${publicationId}"
+    );`
 };

--- a/group-generators/helpers/data-providers/lens-bigquery/queries.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/queries.ts
@@ -58,3 +58,14 @@ export const getWhoMirroredPublicationCountQuery = ({
       WHERE is_related_to_post = "${publicationId}"
     );`
 };
+
+export const getProfilesRankQuery = (rank: number) => {
+    return `SELECT owned_by as address, ROW_NUMBER() OVER(ORDER BY block_timestamp ASC) as value
+    FROM \`lens-public-data.polygon.public_profile\`
+    ORDER BY block_timestamp ASC LIMIT ${rank}`;
+};
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const getProfilesRankCountQuery = (rank: number) => {
+  return `SELECT COUNT(*) FROM \`lens-public-data.polygon.public_profile\``;
+};

--- a/group-generators/helpers/data-providers/lens-bigquery/queries.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/queries.ts
@@ -93,3 +93,19 @@ export const getPublicationReactorsCountQuery = ({
     FROM \`lens-public-data.polygon.public_publication_reaction_records\`
     WHERE publication_id = "${publicationId}" AND reaction = "${reaction}" AND has_undone is FALSE`
 };
+
+export const getWhoCommentedPublicationQuery = ({
+  publicationId
+}: PublicationId) => {
+    return `SELECT profile.owned_by AS address, COUNT(post.comment_by_profile_id) AS value
+    FROM \`lens-public-data.polygon.public_profile\` profile
+    JOIN \`lens-public-data.polygon.public_post_comment\` post ON profile.profile_id = post.comment_by_profile_id
+    WHERE post.post_id = "${publicationId}"
+    GROUP BY profile.owned_by;`
+};
+
+export const getWhoCommentedPublicationCountQuery = ({
+  publicationId
+}: PublicationId) => {
+    return `SELECT COUNT(DISTINCT comment_by_profile_id) FROM \`lens-public-data.polygon.public_post_comment\` WHERE post_id = "${publicationId}"`
+};

--- a/group-generators/helpers/data-providers/lens-bigquery/queries.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/queries.ts
@@ -109,21 +109,6 @@ export const getPublicationReactorsCountQuery = ({
     WHERE publication_id = "${publicationId}" AND reaction = "${reaction}" AND has_undone is FALSE`
 };
 
-export const getProfilesRankQuery = ({
-  rank
-}: RankingCriteria) => {
-    return `SELECT owned_by as address, ROW_NUMBER() OVER(ORDER BY block_timestamp ASC) as value
-    FROM \`lens-public-data.polygon.public_profile\`
-    ORDER BY block_timestamp ASC LIMIT ${rank}`;
-};
-
-export const getProfilesRankCountQuery = ({
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  rank
-}: RankingCriteria) => {
-  return `SELECT COUNT(*) FROM \`lens-public-data.polygon.public_profile\``;
-};
-
 export const getHashtagMentionersQuery = ({
   hashtag
 }: Hashtag) => {
@@ -143,4 +128,19 @@ export const getHashtagMentionersCountQuery = ({
     JOIN \`lens-public-data.polygon.public_profile_post\` post ON profile.profile_id = post.profile_id
     JOIN \`lens-public-data.polygon.public_hashtag\` hashtag ON post.post_id = hashtag.post_id
     WHERE LOWER(hashtag.hashtag) = LOWER("${hashtag}")`
+};
+
+export const getProfilesRankingQuery = ({
+  rank
+}: RankingCriteria) => {
+    return `SELECT owned_by as address, ROW_NUMBER() OVER(ORDER BY block_timestamp ASC) as value
+    FROM \`lens-public-data.polygon.public_profile\`
+    ORDER BY block_timestamp ASC LIMIT ${rank}`;
+};
+
+export const getProfilesRankingCountQuery = ({
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  rank
+}: RankingCriteria) => {
+  return `SELECT COUNT(*) FROM \`lens-public-data.polygon.public_profile\``;
 };

--- a/group-generators/helpers/data-providers/lens-bigquery/queries.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/queries.ts
@@ -131,7 +131,7 @@ export const getHashtagMentionersQuery = ({
     FROM \`lens-public-data.polygon.public_profile\` profile
     JOIN \`lens-public-data.polygon.public_profile_post\` post ON profile.profile_id = post.profile_id
     JOIN \`lens-public-data.polygon.public_hashtag\` hashtag ON post.post_id = hashtag.post_id
-    WHERE hashtag.hashtag = "${hashtag}"
+    WHERE LOWER(hashtag.hashtag) = LOWER("${hashtag}")
     GROUP BY profile.owned_by;`
 };
 
@@ -142,5 +142,5 @@ export const getHashtagMentionersCountQuery = ({
     FROM \`lens-public-data.polygon.public_profile\` profile
     JOIN \`lens-public-data.polygon.public_profile_post\` post ON profile.profile_id = post.profile_id
     JOIN \`lens-public-data.polygon.public_hashtag\` hashtag ON post.post_id = hashtag.post_id
-    WHERE hashtag.hashtag = "${hashtag}"`
+    WHERE LOWER(hashtag.hashtag) = LOWER("${hashtag}")`
 };

--- a/group-generators/helpers/data-providers/lens-bigquery/queries.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/queries.ts
@@ -1,5 +1,5 @@
 import {
-  ProfileId,
+  ProfileId, PublicationId,
 } from "@group-generators/helpers/data-providers/lens/types";
 
 
@@ -17,4 +17,20 @@ export const getFollowersCountQuery = ({
     return `SELECT count(*) 
     FROM \`lens-public-data.polygon.public_follower\` 
     WHERE follow_profile_id = "${profileId}"`;
+};
+
+export const getWhoCollectedPublicationsQuery = ({
+  publicationId
+}: PublicationId) => {
+    return `SELECT owner_address as address, ROW_NUMBER() OVER(ORDER BY block_timestamp ASC) as value
+    FROM \`lens-public-data.polygon.public_collect_post_nft_ownership\`
+    WHERE post_id = "${publicationId}"`;
+};
+
+export const getWhoCollectedPublicationsCountQuery = ({
+  publicationId
+}: PublicationId) => {
+  return `SELECT COUNT(DISTINCT owner_address)
+  FROM \`lens-public-data.polygon.public_collect_post_nft_ownership\`
+  WHERE post_id = "${publicationId}"`;
 };

--- a/group-generators/helpers/data-providers/lens-bigquery/queries.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/queries.ts
@@ -20,7 +20,7 @@ export const getFollowersCountQuery = ({
     WHERE follow_profile_id = "${profileId}"`;
 };
 
-export const getWhoCollectedPublicationQuery = ({
+export const getPublicationCollectorsQuery = ({
   publicationId
 }: PublicationId) => {
     return `SELECT owner_address as address, ROW_NUMBER() OVER(ORDER BY block_timestamp ASC) as value
@@ -28,7 +28,7 @@ export const getWhoCollectedPublicationQuery = ({
     WHERE post_id = "${publicationId}"`;
 };
 
-export const getWhoCollectedPublicationCountQuery = ({
+export const getPublicationCollectorsCountQuery = ({
   publicationId
 }: PublicationId) => {
   return `SELECT COUNT(DISTINCT owner_address)
@@ -36,7 +36,7 @@ export const getWhoCollectedPublicationCountQuery = ({
   WHERE post_id = "${publicationId}"`;
 };
 
-export const getWhoMirroredPublicationQuery = ({
+export const getPublicationMirrorersQuery = ({
   publicationId
 }: PublicationId) => {
     return `SELECT owned_by AS address, ROW_NUMBER() OVER(ORDER BY block_timestamp ASC) as value
@@ -48,7 +48,7 @@ export const getWhoMirroredPublicationQuery = ({
     );`
 };
 
-export const getWhoMirroredPublicationCountQuery = ({
+export const getPublicationMirrorersCountQuery = ({
   publicationId
 }: PublicationId) => {
     return `SELECT COUNT(DISTINCT owned_by)
@@ -60,7 +60,7 @@ export const getWhoMirroredPublicationCountQuery = ({
     );`
 };
 
-export const getWhoCommentedPublicationQuery = ({
+export const getPublicationCommentersQuery = ({
   publicationId
 }: PublicationId) => {
     return `SELECT profile.owned_by AS address, COUNT(post.comment_by_profile_id) AS value
@@ -70,7 +70,7 @@ export const getWhoCommentedPublicationQuery = ({
     GROUP BY profile.owned_by;`
 };
 
-export const getWhoCommentedPublicationCountQuery = ({
+export const getPublicationCommentersCountQuery = ({
   publicationId
 }: PublicationId) => {
     return `SELECT COUNT(DISTINCT profile.profile_id)
@@ -79,7 +79,7 @@ export const getWhoCommentedPublicationCountQuery = ({
     WHERE post.post_id = "${publicationId}"`
 };
 
-export const getWhoReactedToPublicationQuery = ({
+export const getPublicationReactorsQuery = ({
   publicationId,
   reaction
 }: PublicationReaction) => {
@@ -92,7 +92,7 @@ export const getWhoReactedToPublicationQuery = ({
     )`
 };
 
-export const getWhoReactedToPublicationCountQuery = ({
+export const getPublicationReactorsCountQuery = ({
   publicationId,
   reaction
 }: PublicationReaction) => {

--- a/group-generators/helpers/data-providers/lens-bigquery/queries.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/queries.ts
@@ -1,4 +1,4 @@
-import { Hashtag, Profile, Publication, PublicationReaction, RankingCriteria } from "./types";
+import { Hashtag, Profile, Publication, PublicationReaction } from "./types";
 
 export const getFollowersQuery = ({
   profileId
@@ -128,19 +128,4 @@ export const getHashtagMentionersCountQuery = ({
     JOIN \`lens-public-data.polygon.public_profile_post\` post ON profile.profile_id = post.profile_id
     JOIN \`lens-public-data.polygon.public_hashtag\` hashtag ON post.post_id = hashtag.post_id
     WHERE LOWER(hashtag.hashtag) = LOWER("${hashtag}")`
-};
-
-export const getProfilesRankingQuery = ({
-  rank
-}: RankingCriteria) => {
-    return `SELECT owned_by as address, ROW_NUMBER() OVER(ORDER BY block_timestamp ASC) as value
-    FROM \`lens-public-data.polygon.public_profile\`
-    ORDER BY block_timestamp ASC LIMIT ${rank}`;
-};
-
-export const getProfilesRankingCountQuery = ({
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  rank
-}: RankingCriteria) => {
-  return `SELECT COUNT(*) FROM \`lens-public-data.polygon.public_profile\``;
 };

--- a/group-generators/helpers/data-providers/lens-bigquery/types.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/types.ts
@@ -1,0 +1,4 @@
+export type PublicationReaction = {
+  publicationId: string;
+  reaction: string;
+};

--- a/group-generators/helpers/data-providers/lens-bigquery/types.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/types.ts
@@ -6,10 +6,6 @@ export type Publication = {
   publicationId: string;
 };
 
-export type RankingCriteria = {
-  rank: number;
-};
-
 export type PublicationReaction = {
   publicationId: string;
   reaction: string;

--- a/group-generators/helpers/data-providers/lens-bigquery/types.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/types.ts
@@ -2,3 +2,7 @@ export type PublicationReaction = {
   publicationId: string;
   reaction: string;
 };
+
+export type Hashtag = {
+  hashtag: string;
+};

--- a/group-generators/helpers/data-providers/lens-bigquery/types.ts
+++ b/group-generators/helpers/data-providers/lens-bigquery/types.ts
@@ -1,3 +1,15 @@
+export type Profile = {
+  profileId: string;
+};
+
+export type Publication = {
+  publicationId: string;
+};
+
+export type RankingCriteria = {
+  rank: number;
+};
+
 export type PublicationReaction = {
   publicationId: string;
   reaction: string;


### PR DESCRIPTION
- Reproduce the Lens Provider using BigQuery
 - Allow to fetch more data faster
- Add new functions:
  - `getFollowers` (already here in Lens Provider)
  - `getPublicationCollectors` (already here in Lens Provider)
  - `getPublicationMirrorers` (already here in Lens Provider)
  - `getPublicationCommenters`
  - `getPublicationReactors`
  - `getHashtagMentioners`
- Fix groups that got computation issues with the former Lens Provider
- Replace the Lens Provider by the BigQuery Lens provider in the Factory