### PR TITLE
feat: improve and fix data providers

### DIFF
--- a/group-generators/generators/degenscore-beacon-holders/index.ts
+++ b/group-generators/generators/degenscore-beacon-holders/index.ts
@@ -1,0 +1,30 @@
+import { dataProviders } from "@group-generators/helpers/data-providers";
+import { Tags, ValueType, GroupWithData } from "topics/group";
+import { GenerationContext, GenerationFrequency, GroupGenerator } from "topics/group-generator";
+
+const generator: GroupGenerator = {
+  generationFrequency: GenerationFrequency.Daily,
+
+  generate: async (context: GenerationContext): Promise<GroupWithData[]> => {
+    const tokenProvider = new dataProviders.TokenProvider();
+    const holders = await tokenProvider.getERC1155Holders({
+      contractAddress: "0x0521FA0bf785AE9759C7cB3CBE7512EbF20Fbdaa",
+      network: "mainnet",
+    });
+
+    return [
+      {
+        name: "degenscore-beacon-holders",
+        timestamp: context.timestamp,
+        description: "Data Group of DegenScore Beacon Holders",
+        specs:
+          "Created by the Token Data Provider. Contains all addresses that own a DegenScore Beacon (https://degenscore.com/beacon). Value of each group member is the Degen Score of the Beacon.",
+        data: holders,
+        valueType: ValueType.Score,
+        tags: [Tags.Maintained],
+      },
+    ];
+  },
+};
+
+export default generator;

--- a/group-generators/generators/galxe-eth-merge-day-participants/index.ts
+++ b/group-generators/generators/galxe-eth-merge-day-participants/index.ts
@@ -1,10 +1,6 @@
 import { dataProviders } from "@group-generators/helpers/data-providers";
 import { Tags, ValueType, GroupWithData } from "topics/group";
-import {
-  GenerationContext,
-  GenerationFrequency,
-  GroupGenerator,
-} from "topics/group-generator";
+import { GenerationContext, GenerationFrequency, GroupGenerator } from "topics/group-generator";
 
 const generator: GroupGenerator = {
   generationFrequency: GenerationFrequency.Once,
@@ -12,19 +8,20 @@ const generator: GroupGenerator = {
   generate: async (context: GenerationContext): Promise<GroupWithData[]> => {
     const galxeProvider = new dataProviders.GalxeProvider();
     const input = {
-      id: "GCto8UUcU9",
+      id: "GCyruUtEW4",
     };
 
     const galxeData = await galxeProvider.getCampaignHolders(input);
     return [
       {
-        name: "example-galxe",
+        name: "galxe-eth-merge-day-participants",
         timestamp: context.timestamp,
-        description: "get campaign holders from galxe campaign GCto8UUcU9",
-        specs: "campaign GCto8UUcU9",
+        description: 'Data Group of all "ETH Merge Day!" campaign participants',
+        specs:
+          'Created by the Galxe Data Provider. Contains all the holders of the "ETH Merge Day!" campaign(GCyruUtEW4). Value of each group member is the tokenID of the NFT they received from the campaign.',
         data: galxeData,
         valueType: ValueType.Score,
-        tags: [Tags.Factory],
+        tags: [Tags.Maintained],
       },
     ];
   },

--- a/group-generators/generators/guild-sismo-members/index.ts
+++ b/group-generators/generators/guild-sismo-members/index.ts
@@ -13,7 +13,8 @@ const generator: GroupGenerator = {
         name: "guild-sismo-members",
         displayName: "Sismo Guild Members",
         description: "Data Group of all members of the Sismo Guild",
-        specs: "Created by the Guild Data Provider. Contains all the members of the Sismo Guild.",
+        specs:
+          "Created by the Guild Data Provider. Contains all the members of the Sismo Guild. Value of each group member is the roleId of the role to which it belongs.",
         timestamp: context.timestamp,
         data: addresses,
         valueType: ValueType.Info,

--- a/group-generators/generators/index.ts
+++ b/group-generators/generators/index.ts
@@ -146,6 +146,7 @@ import degenSwag from "./degen-swag";
 import degens from "./degens";
 import degens1500 from "./degens-1500";
 import degenscoreBeacon from "./degenscore-beacon";
+import degenscoreBeaconHolders from "./degenscore-beacon-holders";
 import degenscoreOver900 from "./degenscore-over-900";
 import delovoyDaoChristmas from "./delovoy-dao-christmas";
 import demoGroupAciDelegators from "./demo-group-aci-delegators";
@@ -967,6 +968,7 @@ export const groupGenerators: GroupGeneratorsLibrary = {
   "degens": degens,
   "degens-1500": degens1500,
   "degenscore-beacon": degenscoreBeacon,
+  "degenscore-beacon-holders": degenscoreBeaconHolders,
   "degenscore-over-900": degenscoreOver900,
   "delovoy-dao-christmas": delovoyDaoChristmas,
   "demo-group-aci-delegators": demoGroupAciDelegators,

--- a/group-generators/generators/index.ts
+++ b/group-generators/generators/index.ts
@@ -219,7 +219,6 @@ import ethporto from "./ethporto";
 import eventsInCommonWithDydymoon from "./events-in-common-with-dydymoon";
 import everwaveFounder from "./everwave-founder";
 import exampleAlchemy from "./example-alchemy"
-import exampleGalxe from "./example-galxe"
 import exampleLayer3 from "./example-layer3"
 import exampleMirrorXyz from "./example-mirrorxyz"
 import exampleRep3 from "./example-rep3"
@@ -258,6 +257,7 @@ import gabinFollowersOnLens from "./gabin-followers-on-lens";
 import gabriel from "./gabriel";
 import gachi from "./gachi";
 import gachiKrut from "./gachi-krut";
+import galxeEthMergeDayParticipants from './galxe-eth-merge-day-participants';
 import galxePassport from "./galxe-passport"
 import gamejustuAchievements from "./gamejutsu-achievements";
 import garagepunk from "./garagepunk";
@@ -1119,7 +1119,6 @@ export const groupGenerators: GroupGeneratorsLibrary = {
   "ethporto": ethporto,
   "everwave-founder": everwaveFounder,
   "example-alchemy": exampleAlchemy,
-  "example-galxe": exampleGalxe,
   "example-layer3": exampleLayer3,
   "example-mirrorxyz": exampleMirrorXyz,
   "example-rep3": exampleRep3,
@@ -1150,6 +1149,7 @@ export const groupGenerators: GroupGeneratorsLibrary = {
   "gabriel": gabriel,
   "gachi": gachi,
   "gachi-krut": gachiKrut,
+  "galxe-eth-merge-day-participants": galxeEthMergeDayParticipants,
   "galxe-passport": galxePassport,
   "gamejutsu-achievements": gamejustuAchievements,
   "garagepunk": garagepunk,

--- a/group-generators/helpers/data-providers/alchemy/index.ts
+++ b/group-generators/helpers/data-providers/alchemy/index.ts
@@ -102,13 +102,13 @@ export class AlchemyProvider {
     this.contractAddress = contractAddress;
     let groupData: FetchedData = {};
     for (const tokenId of tokenIds) {
-      const owners = await this._getOwnersOfTokenIds(tokenId);
+      const owners = await this._getOwnersOfTokenId(tokenId);
       groupData = { ...groupData, ...owners };
     }
     return groupData;
   }
 
-  private async _getOwnersOfTokenIds(tokenId: string): Promise<FetchedData> {
+  private async _getOwnersOfTokenId(tokenId: string): Promise<FetchedData> {
     let pageKey = "";
     let hasNext = true;
     const ownersList: FetchedData = {};

--- a/group-generators/helpers/data-providers/alchemy/index.ts
+++ b/group-generators/helpers/data-providers/alchemy/index.ts
@@ -100,23 +100,23 @@ export class AlchemyProvider {
   }: GetOwnersOfTokenIdsParams): Promise<FetchedData> {
     this.baseUrl = this.urlQueryHandler(chain);
     this.contractAddress = contractAddress;
-    const groupData: FetchedData = {};
+    let groupData: FetchedData = {};
     for (const tokenId of tokenIds) {
       const owners = await this._getOwnersOfTokenIds(tokenId);
-      for (const owner of owners) {
-        groupData[owner] = 1;
-      }
+      groupData = { ...groupData, ...owners };
     }
     return groupData;
   }
 
-  private async _getOwnersOfTokenIds(tokenId: string) {
+  private async _getOwnersOfTokenIds(tokenId: string): Promise<FetchedData> {
     let pageKey = "";
     let hasNext = true;
-    const ownersList: string[] = [];
+    const ownersList: FetchedData = {};
     while (hasNext) {
       const response = await this._getOwnersOfTokenIdsQuery(pageKey, tokenId);
-      ownersList.push(...response.owners);
+      for (const owner of response.owners) {
+        ownersList[owner] = tokenId;
+      }
       hasNext = !!response.pageKey;
       pageKey = response.pageKey;
     }

--- a/group-generators/helpers/data-providers/alchemy/interface-schema.json
+++ b/group-generators/helpers/data-providers/alchemy/interface-schema.json
@@ -7,7 +7,7 @@
       "name": "Get Owners for Collection",
       "functionName": "getOwnersForCollection",
       "countFunctionName": "getOwnersForCollectionCount",
-      "description": "Retrieves the owners of all NFTs for a given collection.",
+      "description": "Retrieves the owners of all NFTs for a given collection. The value of each owner is their total tokens balance.",
       "args": [
         {
           "name": "Contract Address",

--- a/group-generators/helpers/data-providers/alchemy/types.ts
+++ b/group-generators/helpers/data-providers/alchemy/types.ts
@@ -43,26 +43,14 @@ export const fromStringToSupportedNetwork = (network: string): SupportedNetwork 
 };
 
 export interface IAlchemyProvider {
-  getOwnersForCollection(
-    Params: GetOwnersForCollectionParams
-  ): Promise<FetchedData>;
-  getOwnersForCollectionCount(
-    Params: GetOwnersForCollectionParams
-  ): Promise<number>;
+  getOwnersForCollection(Params: GetOwnersForCollectionParams): Promise<FetchedData>;
+  getOwnersForCollectionCount(Params: GetOwnersForCollectionParams): Promise<number>;
   getOwnersOfTokenIds(Params: GetOwnersOfTokenIdsParams): Promise<FetchedData>;
   getOwnersOfTokenIdsCount(Params: GetOwnersOfTokenIdsParams): Promise<number>;
-  getOwnersOfNftsMatchingTrait(
-    Params: GetOwnersOfNftsMatchingTraitParams
-  ): Promise<FetchedData>;
-  getOwnersOfNftsMatchingTraitCount(
-    Params: GetOwnersOfNftsMatchingTraitParams
-  ): Promise<number>;
-  getTokenIdsOfContract(
-    Params: GetTokenIdsOfContractParams
-  ): Promise<FetchedData>;
-  getTokenIdsOfContractCount(
-    Params: GetTokenIdsOfContractParams
-  ): Promise<number>;
+  getOwnersOfNftsMatchingTrait(Params: GetOwnersOfNftsMatchingTraitParams): Promise<FetchedData>;
+  getOwnersOfNftsMatchingTraitCount(Params: GetOwnersOfNftsMatchingTraitParams): Promise<number>;
+  getTokenIdsOfContract(Params: GetTokenIdsOfContractParams): Promise<FetchedData>;
+  getTokenIdsOfContractCount(Params: GetTokenIdsOfContractParams): Promise<number>;
 }
 
 export type GetOwnersForCollectionParams = {
@@ -71,8 +59,18 @@ export type GetOwnersForCollectionParams = {
 };
 
 export type GetOwnersForCollectionResponse = {
-  ownerAddresses: string[];
+  ownerAddresses: GetOwnersForCollectionResponseData[];
   pageKey: string;
+};
+
+export type GetOwnersForCollectionResponseData = {
+  ownerAddress: string;
+  tokenBalances: tokenBalances[];
+};
+
+export type tokenBalances = {
+  tokenId: string;
+  balance: number;
 };
 
 export type GetOwnersOfTokenIdsParams = {

--- a/group-generators/helpers/data-providers/ankr/interface-schema.json
+++ b/group-generators/helpers/data-providers/ankr/interface-schema.json
@@ -7,7 +7,7 @@
       "name": "Get holders of Token",
       "functionName": "getTokenHolders",
       "countFunctionName": "getTokenHoldersCount",
-      "description": "Returns all holders of a specific token",
+      "description": "Returns all holders of a specific token. The value of each holder is their total tokens balance.",
       "args": [
         {
           "name": "TokenAddress",

--- a/group-generators/helpers/data-providers/degenscore/index.ts
+++ b/group-generators/helpers/data-providers/degenscore/index.ts
@@ -27,7 +27,7 @@ export class DegenScoreProvider {
     const returnData: FetchedData = {};
     Object.keys(enrichedData).forEach((holder: string) => {
       if (enrichedData[holder] >= score) {
-        returnData[holder] = 1;
+        returnData[holder] = enrichedData[holder];
       }
     });
     return returnData;

--- a/group-generators/helpers/data-providers/degenscore/index.ts
+++ b/group-generators/helpers/data-providers/degenscore/index.ts
@@ -1,32 +1,33 @@
 import axios from "axios";
-import { BeaconResponse, Score } from "./types";
+import { BigNumber } from "ethers";
+import { Beacon, BeaconResponse, Score } from "./types";
 import { FetchedData } from "topics/group";
 
 export class DegenScoreProvider {
   public async getBeaconOwnersWithScore({ score }: Score) {
     // fetch Beacons from API
-    const enrichedData: any = {};
+    const enrichedData: FetchedData = {};
     let cursor = "";
     do {
       const data: BeaconResponse = await this.getBeacons(cursor);
 
       // Check if there is a next cursor
-      if (Object.values(data["meta"]).length > 0) {
-        cursor = "&cursor=" + data["meta"]["nextCursor"];
+      if (Object.values(data.meta).length > 0) {
+        cursor = "&cursor=" + data.meta.nextCursor;
       } else {
         cursor = "";
       }
 
       // Add holder of each beacon
-      data["beacons"].map(async (elem: any) => {
-        enrichedData[elem["address"]] = elem["primaryTraits"]["degen_score"];
+      data.beacons.map(async (elem: Beacon) => {
+        enrichedData[elem.address] = elem.primaryTraits.degen_score;
       });
     } while (cursor);
 
     // filter for score over preset
     const returnData: FetchedData = {};
     Object.keys(enrichedData).forEach((holder: string) => {
-      if (enrichedData[holder] >= score) {
+      if (BigNumber.from(enrichedData[holder]).gte(BigNumber.from(score))) {
         returnData[holder] = enrichedData[holder];
       }
     });

--- a/group-generators/helpers/data-providers/degenscore/types.ts
+++ b/group-generators/helpers/data-providers/degenscore/types.ts
@@ -1,16 +1,16 @@
 export type Score = { score: number };
 
 export type BeaconResponse = {
-  beacons: [
-    {
-      address: string;
-      primaryTraits: {
-        degenScore: string;
-      };
-      updatedAt: string;
-    }
-  ];
+  beacons: Beacon[];
   meta: {
     nextCursor: string;
   };
+};
+
+export type Beacon = {
+  address: string;
+  primaryTraits: {
+    degen_score: string;
+  };
+  updatedAt: string;
 };

--- a/group-generators/helpers/data-providers/ens-subdomain/index.ts
+++ b/group-generators/helpers/data-providers/ens-subdomain/index.ts
@@ -27,7 +27,7 @@ export class EnsSubdomainProvider extends GraphQLProvider implements IEnsSubdoma
         if (res.domains[0].subdomains.length > 0) {
           res.domains[0].subdomains.forEach((subdomain) => {
             subdomainHolders[subdomain.owner.id] = BigNumber.from(
-              subdomainHolders[subdomain.owner.id] || 0
+              subdomainHolders[subdomain.owner.id] ?? 0
             )
               .add(1)
               .toString();

--- a/group-generators/helpers/data-providers/ens-subdomain/index.ts
+++ b/group-generators/helpers/data-providers/ens-subdomain/index.ts
@@ -1,26 +1,18 @@
+import { BigNumber } from "ethers";
 import { gql } from "graphql-request";
-import {
-  EnsSubdomainResponse,
-  EnsDomainParams,
-  IEnsSubdomainProvider,
-} from "./types";
+import { EnsSubdomainResponse, EnsDomainParams, IEnsSubdomainProvider } from "./types";
 import { GraphQLProvider } from "@group-generators/helpers/data-providers/graphql";
 
 import { FetchedData } from "topics/group";
 
-export class EnsSubdomainProvider
-  extends GraphQLProvider
-  implements IEnsSubdomainProvider
-{
+export class EnsSubdomainProvider extends GraphQLProvider implements IEnsSubdomainProvider {
   constructor() {
     super({
       url: "https://api.thegraph.com/subgraphs/name/ensdomains/ens",
     });
   }
 
-  public async getEnsSubdomains({
-    domain,
-  }: EnsDomainParams): Promise<FetchedData> {
+  public async getEnsSubdomains({ domain }: EnsDomainParams): Promise<FetchedData> {
     domain.endsWith(".eth") ? domain : (domain += ".eth");
     const domainLowerCase = domain.toLowerCase();
     try {
@@ -30,15 +22,15 @@ export class EnsSubdomainProvider
       const subdomainHolders: FetchedData = {};
 
       while (continuePaging) {
-        const res: EnsSubdomainResponse = await this.fetchPage(
-          domainLowerCase,
-          skip,
-          pageSize
-        );
+        const res: EnsSubdomainResponse = await this.fetchPage(domainLowerCase, skip, pageSize);
 
         if (res.domains[0].subdomains.length > 0) {
           res.domains[0].subdomains.forEach((subdomain) => {
-            subdomainHolders[subdomain.owner.id] = 1;
+            subdomainHolders[subdomain.owner.id] = BigNumber.from(
+              subdomainHolders[subdomain.owner.id] || 0
+            )
+              .add(1)
+              .toString();
           });
           skip += pageSize;
         } else {
@@ -82,9 +74,7 @@ export class EnsSubdomainProvider
     });
   }
 
-  public async getEnsSubdomainsCount({
-    domain,
-  }: EnsDomainParams): Promise<number> {
+  public async getEnsSubdomainsCount({ domain }: EnsDomainParams): Promise<number> {
     const domainLowerCase = domain.toLowerCase();
     const holders = await this.getEnsSubdomains({
       domain: domainLowerCase,

--- a/group-generators/helpers/data-providers/galxe/index.ts
+++ b/group-generators/helpers/data-providers/galxe/index.ts
@@ -15,8 +15,8 @@ export class GalxeProvider extends GraphQLProvider implements IGalxeProvider {
     let response: QueryCampaignOutput;
     let cursor = 0;
 
-    // Get last block number - 100 to avoid errors (API can be late)
-    const lastBlockNumber = (await ethers.getDefaultProvider().getBlockNumber()) - 100;
+    // Get last block number - 1000 to avoid errors (API can be late)
+    const lastBlockNumber = (await ethers.getDefaultProvider().getBlockNumber()) - 1000;
 
     do {
       try {

--- a/group-generators/helpers/data-providers/galxe/index.ts
+++ b/group-generators/helpers/data-providers/galxe/index.ts
@@ -16,7 +16,7 @@ export class GalxeProvider extends GraphQLProvider implements IGalxeProvider {
     let cursor = 0;
 
     // Get last block number - 1000 to avoid errors (API can be late)
-    const lastBlockNumber = (await ethers.getDefaultProvider().getBlockNumber()) - 1000;
+    const lastBlockNumber = (await ethers.getDefaultProvider().getBlockNumber()) - 10000;
 
     do {
       try {
@@ -45,8 +45,8 @@ export class GalxeProvider extends GraphQLProvider implements IGalxeProvider {
         });
 
         if (response.campaign.nftHolderSnapshot.holders.list.length) {
-          for (const holder of response.campaign.nftHolderSnapshot.holders.list) {
-            holders[holder.holder] = holder.id;
+          for (const holderProfile of response.campaign.nftHolderSnapshot.holders.list) {
+            holders[holderProfile.holder] = holderProfile.id;
           }
 
           cursor += response.campaign.nftHolderSnapshot.holders.list.length;

--- a/group-generators/helpers/data-providers/galxe/index.ts
+++ b/group-generators/helpers/data-providers/galxe/index.ts
@@ -1,9 +1,6 @@
+import { ethers } from "ethers";
 import { gql } from "graphql-request";
-import {
-  QueryCampaignOutput,
-  QueryCampaignInput,
-  IGalxeProvider,
-} from "./types";
+import { QueryCampaignOutput, QueryCampaignInput, IGalxeProvider } from "./types";
 
 import { GraphQLProvider } from "@group-generators/helpers/data-providers/graphql";
 import { FetchedData } from "topics/group";
@@ -13,49 +10,55 @@ export class GalxeProvider extends GraphQLProvider implements IGalxeProvider {
     super({ url: "https://graphigo.prd.galaxy.eco/query" });
   }
 
-  public async getCampaignHolders({
-    id,
-  }: QueryCampaignInput): Promise<FetchedData> {
+  public async getCampaignHolders({ id }: QueryCampaignInput): Promise<FetchedData> {
     const holders: FetchedData = {};
     let response: QueryCampaignOutput;
     let cursor = 0;
 
-    do{
+    // Get last block number - 100 to avoid errors (API can be late)
+    const lastBlockNumber = (await ethers.getDefaultProvider().getBlockNumber()) - 100;
+
+    do {
       try {
         const query = gql`
-          query Campaign($id: ID!, $cursor: String!) {
+          query Campaign($id: ID!, $block: Int!, $cursor: String!) {
             campaign(id: $id) {
               id
               status
               numNFTMinted
-              holdersList(first: 1000, after: $cursor)
+              nftHolderSnapshot {
+                holders(block: $block, first: 1000, after: $cursor) {
+                  list {
+                    holder
+                    id
+                  }
+                }
+              }
             }
-        }
+          }
         `;
-        
+
         response = await this.query<QueryCampaignOutput>(query, {
           id,
+          block: lastBlockNumber,
           cursor: cursor.toString(),
         });
 
-        if(response.campaign.holdersList){
-          for (const holder of response.campaign.holdersList) {
-            holders[holder] = 1;
+        if (response.campaign.nftHolderSnapshot.holders.list.length) {
+          for (const holder of response.campaign.nftHolderSnapshot.holders.list) {
+            holders[holder.holder] = holder.id;
           }
-  
-          cursor += response.campaign.holdersList.length;
-        }
 
+          cursor += response.campaign.nftHolderSnapshot.holders.list.length;
+        }
       } catch (error) {
         throw new Error("Error fetching campaign holders");
       }
-    } while (response.campaign.holdersList);
+    } while (response.campaign.nftHolderSnapshot.holders.list.length > 0);
     return holders;
   }
 
-  public async getCampaignHoldersCount({
-    id,
-  }: QueryCampaignInput): Promise<number> {
+  public async getCampaignHoldersCount({ id }: QueryCampaignInput): Promise<number> {
     const holders = await this.getCampaignHolders({ id });
     return Object.keys(holders).length;
   }

--- a/group-generators/helpers/data-providers/galxe/interface-schema.json
+++ b/group-generators/helpers/data-providers/galxe/interface-schema.json
@@ -7,7 +7,7 @@
       "name": "Get holders of a campaign NFT",
       "functionName": "getCampaignHolders",
       "countFunctionName": "getCampaignHoldersCount",
-      "description": "Returns all holders of a specific galaxe campaign",
+      "description": "Returns all holders of a specific galaxe campaign. The value of each group member is the tokenId of the campaign NFT.",
       "args": [
         {
           "name": "CampaignID",

--- a/group-generators/helpers/data-providers/galxe/types.ts
+++ b/group-generators/helpers/data-providers/galxe/types.ts
@@ -6,7 +6,16 @@ export type QueryCampaignOutput = {
     id: string;
     status: string;
     numNFTMinted: number;
-    holdersList: string[];
+    nftHolderSnapshot: NftHolderSnapshot;
+  };
+};
+
+export type NftHolderSnapshot = {
+  holders: {
+    list: {
+      holder: string;
+      id: string;
+    }[];
   };
 };
 

--- a/group-generators/helpers/data-providers/guild/index.ts
+++ b/group-generators/helpers/data-providers/guild/index.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { GuildApiResponse, GuildName, RoleApiResponse, RoleId } from "./types";
+import { GuildApiResponse, GuildName, RoleApiResponse, RoleRequest } from "./types";
 import { dataOperators } from "@group-generators/helpers/data-operators";
 import { FetchedData } from "topics/group";
 
@@ -14,14 +14,13 @@ export class GuildProvider {
     try {
       // fetch all roles in guild
       let users: FetchedData = {};
-      const res: GuildApiResponse = await this.getGuildConnection(
-        `guild/${name}`
-      );
+      const res: GuildApiResponse = await this.getGuildConnection(`guild/${name}`);
+
       const roles = res.roles;
 
       // fetch members of each role in guild
-      for(const role of roles) {
-        const members = await this.getRoleMembers({ id: role.id });
+      for (const role of roles) {
+        const members = await this.getRoleMembers({ id: role.id, roleValue: true });
         users = dataOperators.Union([users, members]);
       }
       return users;
@@ -35,13 +34,13 @@ export class GuildProvider {
     return Object.keys(res).length;
   }
 
-  public async getRoleMembers({ id: id }: RoleId): Promise<FetchedData> {
+  public async getRoleMembers({ id: id, roleValue: roleValue }: RoleRequest): Promise<FetchedData> {
     try {
       // fetch all members of guild
       const res: RoleApiResponse = await this.getGuildConnection(`role/${id}`);
       const users: FetchedData = {};
       res.members.forEach((member) => {
-        users[member] = 1;
+        users[member] = roleValue ? res.id : 1;
       });
       return users;
     } catch (error) {
@@ -49,7 +48,7 @@ export class GuildProvider {
     }
   }
 
-  public async getRoleMembersCount({ id }: RoleId): Promise<number> {
+  public async getRoleMembersCount({ id }: RoleRequest): Promise<number> {
     const res = await this.getRoleMembers({ id: id });
     return Object.keys(res).length;
   }

--- a/group-generators/helpers/data-providers/guild/interface-schema.json
+++ b/group-generators/helpers/data-providers/guild/interface-schema.json
@@ -7,7 +7,7 @@
       "name": "Get members of Guild",
       "functionName": "getGuildMembers",
       "countFunctionName": "getGuildMembersCount",
-      "description": "Returns all members of a specific Guild",
+      "description": "Returns all members of a specific Guild. The value of each group member is the roleId of the role they belong to.",
       "args": [
         {
           "name": "Guild",

--- a/group-generators/helpers/data-providers/guild/types.ts
+++ b/group-generators/helpers/data-providers/guild/types.ts
@@ -21,6 +21,7 @@ export type GuildName = {
   name: string;
 };
 
-export type RoleId = {
+export type RoleRequest = {
   id: number;
+  roleValue?: boolean;
 };

--- a/group-generators/helpers/data-providers/index.ts
+++ b/group-generators/helpers/data-providers/index.ts
@@ -7,7 +7,6 @@ import ankrInterfaceSchema from "./ankr/interface-schema.json";
 import { AttestationStationProvider } from "./atst";
 import { BigQueryProvider } from "./big-query/big-query";
 import { DegenScoreProvider } from "./degenscore";
-import degenScoreInterfaceSchema from "./degenscore/interface-schema.json";
 import { DiscourseProvider } from "./discourse";
 import { DuneProvider } from "./dune";
 import { EthereumAttestationServiceProvider } from "./eas";
@@ -105,7 +104,6 @@ export const dataProviders = {
 export const dataProvidersInterfacesSchemas: DataProviderInterface[] = [
   alchemyInterfaceSchema,
   ankrInterfaceSchema,
-  degenScoreInterfaceSchema,
   ethereumAttestationServiceInterfaceSchema,
   ensSubdomainInterfaceSchema,
   galxeInterfaceSchema,
@@ -155,10 +153,6 @@ export const dataProvidersAPIEndpoints = {
   AnkrProvider: {
     getTokenHoldersCount: async (_: any) => new AnkrProvider().getTokenHoldersCount(_),
     getNftHoldersCount: async (_: any) => new AnkrProvider().getNftHoldersCount(_),
-  },
-  DegenScoreProvider: {
-    getBeaconOwnersWithScoreCount: async (_: any) =>
-      new DegenScoreProvider().getBeaconOwnersWithScoreCount(_),
   },
   EnsSubdomainProvider: {
     getEnsSubdomainsCount: async (_: any) => new EnsSubdomainProvider().getEnsSubdomainsCount(_),

--- a/group-generators/helpers/data-providers/otterspace/interface-schema.json
+++ b/group-generators/helpers/data-providers/otterspace/interface-schema.json
@@ -7,7 +7,7 @@
       "name": "Get holders of badge",
       "functionName": "getBadgeHolders",
       "countFunctionName": "getBadgeHoldersCount",
-      "description": "Returns all holders of a specific Otterspace badge",
+      "description": "Returns all holders of a specific Otterspace badge. The value of each group member is the timestamp of the block in which the badge was minted.",
       "args": [
         {
           "name": "BadgeId",

--- a/group-generators/helpers/data-providers/otterspace/types.ts
+++ b/group-generators/helpers/data-providers/otterspace/types.ts
@@ -7,13 +7,48 @@ export type QueryBadgeHoldersOutput = {
     badges: [
       {
         id: string;
-        owner: string;
+        owner: {
+          id: string;
+        };
+        createdAt: number;
       }
     ];
   };
 };
 
-export type QueryBadgeHoldersInput = { id: string };
+export type QueryBadgeHoldersInput = {
+  id: string;
+};
+
+export enum SupportedNetworkLink {
+  ETH = "https://api.thegraph.com/subgraphs/name/otterspace-xyz/badges-mainnet",
+  POLYGON = "https://api.thegraph.com/subgraphs/name/otterspace-xyz/badges-polygon",
+  OPTIMISM = "https://thegraph.com/hosted-service/subgraph/otterspace-xyz/badges-optimism",
+  GOERLI = "https://api.thegraph.com/subgraphs/name/otterspace-xyz/badges-goerli",
+  OPTIMISM_GOERLI = "https://api.thegraph.com/subgraphs/name/otterspace-xyz/badges-optimism-goerli",
+}
+
+export const fromStringToSupportedNetworkLink = (network: string): SupportedNetworkLink => {
+  switch (network) {
+    case "eth":
+    case "1":
+      return SupportedNetworkLink.ETH;
+    case "polygon":
+    case "137":
+      return SupportedNetworkLink.POLYGON;
+    case "optimism":
+    case "10":
+      return SupportedNetworkLink.OPTIMISM;
+    case "eth_goerli":
+    case "5":
+      return SupportedNetworkLink.GOERLI;
+    case "opt-goerli":
+    case "420":
+      return SupportedNetworkLink.OPTIMISM_GOERLI;
+    default:
+      throw new Error(`Unsupported network named ${network}`);
+  }
+};
 
 export interface IOtterspaceSubgraphProvider extends ISubgraphProvider {
   getBadgeHolders(input: QueryBadgeHoldersInput): Promise<FetchedData>;

--- a/group-generators/helpers/data-providers/unlock/index.ts
+++ b/group-generators/helpers/data-providers/unlock/index.ts
@@ -15,16 +15,11 @@ export class UnlockSubgraphProvider
 {
   constructor(url?: string) {
     super({
-      url:
-        url ??
-        "https://api.thegraph.com/subgraphs/name/unlock-protocol/mainnet-v2",
+      url: url ?? "https://api.thegraph.com/subgraphs/name/unlock-protocol/mainnet-v2",
     });
   }
 
-  public async getKeysInLock({
-    lockAddress,
-    chain,
-  }: QueryUnlockInput): Promise<FetchedData> {
+  public async getKeysInLock({ lockAddress, chain }: QueryUnlockInput): Promise<FetchedData> {
     this.setUrl(chain);
     const query = gql`
       query locks {
@@ -37,6 +32,7 @@ export class UnlockSubgraphProvider
             owner {
               address
             }
+            tokenId
             expiration
           }
         }
@@ -48,7 +44,7 @@ export class UnlockSubgraphProvider
 
     if (res.locks.length > 0) {
       res.locks[0].keys.forEach((key) => {
-        holders[key.owner] = 1;
+        holders[key.owner] = key.tokenId;
       });
 
       return holders;
@@ -57,10 +53,7 @@ export class UnlockSubgraphProvider
     }
   }
 
-  public async getKeysInLockCount({
-    lockAddress,
-    chain,
-  }: QueryUnlockInput): Promise<number> {
+  public async getKeysInLockCount({ lockAddress, chain }: QueryUnlockInput): Promise<number> {
     const keys = await this.getKeysInLock({
       lockAddress,
       chain,

--- a/group-generators/helpers/data-providers/unlock/interface-schema.json
+++ b/group-generators/helpers/data-providers/unlock/interface-schema.json
@@ -7,7 +7,7 @@
       "name": "Get keys in lock",
       "functionName": "getKeysInLock",
       "countFunctionName": "getKeysInLockCount",
-      "description": "Returns all key holders of a lock",
+      "description": "Returns all key holders of a lock. The value of each group member is the tokenId",
       "args": [
         {
           "name": "LockAddress",

--- a/group-generators/helpers/data-providers/unlock/types.ts
+++ b/group-generators/helpers/data-providers/unlock/types.ts
@@ -4,15 +4,13 @@ import { FetchedData } from "topics/group";
 export enum ChainSelectorType {
   MAINNET = "https://api.thegraph.com/subgraphs/name/unlock-protocol/mainnet-v2",
   GOERLI = "https://api.thegraph.com/subgraphs/name/unlock-protocol/goerli-v2",
-  OPTIMISM =
-    "https://api.thegraph.com/subgraphs/name/unlock-protocol/optimism-v2",
+  OPTIMISM = "https://api.thegraph.com/subgraphs/name/unlock-protocol/optimism-v2",
   BSC = "https://api.thegraph.com/subgraphs/name/unlock-protocol/bsc-v2",
   GNOSIS = "https://api.thegraph.com/subgraphs/name/unlock-protocol/gnosis-v2",
   POLYGON = "https://api.thegraph.com/subgraphs/name/unlock-protocol/polygon-v2",
   ARBITRUM = "https://api.thegraph.com/subgraphs/name/unlock-protocol/arbitrum-v2",
   CELO = "https://api.thegraph.com/subgraphs/name/unlock-protocol/celo-v2",
-  AVALANCHE =
-    "https://api.thegraph.com/subgraphs/name/unlock-protocol/avalanche-v2",
+  AVALANCHE = "https://api.thegraph.com/subgraphs/name/unlock-protocol/avalanche-v2",
 }
 
 export const fromStringToSupportedNetwork = (network: string): ChainSelectorType => {
@@ -56,6 +54,7 @@ export type QueryUnlockOutput = {
         {
           owner: string;
           expiration: string;
+          tokenId: string;
         }
       ];
     }


### PR DESCRIPTION
**TL;DR: this PR fix some issue we had on a few Data Provider functions, add something as value (balance, tokenId, creation date...) for the group (and not just a defaultValue), and also remove useless providers.**

Details:
- **Alchemy Provider:**
  - feat: NFT Balance as value for getOwnersForCollection() function
  - fix: getOwnersOfTokenIds function (wasn’t working anymore) + put tokenId as value (not possible to have the balance for this one)
- **Ankr provider:**
  - feat: put balance as values for getTokenHolders (ERC-20 holders)  (not possible to have other things as value for NFT holders function)
- **DegenScore Provider:**
  - feat: put the degen score as value instead of the minimal score specified
  - Finally decided to remove it from factory because it’s just a fetch of onchain ERC-1155, so I we can fetch them using the token provider
  - Also no need to have a data provider for this: we don’t want to generate sub group of degenscore address, we want only 1 (source of truth) group and generate zk-proof from it.
  - So I created a new maintained group degenscore-beacon-holders (using the token provider)
- **ENS Subdomains Provider:**
  - Put the number of subdomain hold as value
- **Ethleaderboard Provider:** just un update here: like hive it’s also not updated anymore because of twitter API
- **Galxe Provider:**
  - fix: there was a deprecated attribute use in the request so I updated it
  - feat: put the tokenId as value (couldn’t put the balance unfortunately)
  - feat: created a new maintained group galxe-eth-merge-day (https://galxe.com/taiko/campaign/GCyruUtEW4) (this will replace the current: « exemple galxe » group). it allows us to have an maintained group for this Data Provider
- **Guild Provider:**
  - feat: put the roleId as value (I updated the description of the maintained group that use this provider)
- **Otterspace Provider:**
  - fix: the provider because it wasn’t working anymore
  - feat: add multiple networks (not only optimism)
  - feat: put creationDate of the badge as value (it’s the only interesting thing I could to implement)
  - I’ll also create a maintained group after the merge of this PR (so we have an example for this data provider too)
- **Unlock Provider:**
  - feat: put tokenId as value