### PR TITLE
fix: tokenProvider ERC20 function

### DIFF
--- a/group-generators/generators/aave-holders/index.ts
+++ b/group-generators/generators/aave-holders/index.ts
@@ -1,31 +1,22 @@
-
 import { dataOperators } from "@group-generators/helpers/data-operators";
 import { dataProviders } from "@group-generators/helpers/data-providers";
 import { Tags, ValueType, GroupWithData } from "topics/group";
-import {
-  GenerationContext,
-  GenerationFrequency,
-  GroupGenerator,
-} from "topics/group-generator";
+import { GenerationContext, GenerationFrequency, GroupGenerator } from "topics/group-generator";
 
 const generator: GroupGenerator = {
-  
   generationFrequency: GenerationFrequency.Weekly,
-  
+
   generate: async (context: GenerationContext): Promise<GroupWithData[]> => {
-  
     const tokenProvider = new dataProviders.TokenProvider();
-    
+
     const tokenProviderData0 = await tokenProvider.getERC20Holders({
       network: "mainnet",
-      tokenDecimals: 18,
-      contractAddress: "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9"
+      contractAddress: "0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9",
     });
 
     const tokenProviderData1 = await tokenProvider.getERC20Holders({
       network: "polygon",
-      tokenDecimals: 18,
-      contractAddress: "0xD6DF932A45C0f255f85145f286eA0b292B21C90B"
+      contractAddress: "0xD6DF932A45C0f255f85145f286eA0b292B21C90B",
     });
 
     const aaveHolders = dataOperators.Union([tokenProviderData0, tokenProviderData1]);
@@ -35,7 +26,8 @@ const generator: GroupGenerator = {
         name: "aave-holders",
         timestamp: context.timestamp,
         description: "Datagroup of all aave holders",
-        specs: "Created By the Token Provider. Contains of all aave holders on Ethereum mainnet, an Polygon POS. Value for each group member is the number of Token held.",
+        specs:
+          "Created By the Token Provider. Contains of all aave holders on Ethereum mainnet, an Polygon POS. Value for each group member is the number of Token held.",
         data: aaveHolders,
         valueType: ValueType.Score,
         tags: [Tags.Factory, Tags.Maintained],

--- a/group-generators/generators/apecoin-holders-by-chimeradefi/index.ts
+++ b/group-generators/generators/apecoin-holders-by-chimeradefi/index.ts
@@ -19,7 +19,6 @@ const generator: GroupGenerator = {
     
     const tokenProviderData0 = await tokenProvider.getERC20Holders({
       contractAddress: "0x4d224452801ACEd8B2F0aebE155379bb5D594381",
-      tokenDecimals: 18,
     });
 
     return [

--- a/group-generators/generators/clamato/index.ts
+++ b/group-generators/generators/clamato/index.ts
@@ -19,7 +19,6 @@ const generator: GroupGenerator = {
     
     const tokenProviderData0 = await tokenProvider.getERC20Holders({
       contractAddress: "0x758b4684be769e92eefea93f60dda0181ea303ec",
-      tokenDecimals: 18,
     });
 
     return [

--- a/group-generators/generators/crypto-punks-holders/index.ts
+++ b/group-generators/generators/crypto-punks-holders/index.ts
@@ -20,7 +20,6 @@ const generator: GroupGenerator = {
     const tokenProviderData0 = await tokenProvider.getERC20Holders({
       contractAddress: "0xb47e3cd837ddf8e4c57f05d70ab865de6e193bbb",
       network: "mainnet",
-      tokenDecimals: 0,
     });
 
     return [

--- a/group-generators/generators/first-1000-phonon-mainnet-holders/index.ts
+++ b/group-generators/generators/first-1000-phonon-mainnet-holders/index.ts
@@ -19,7 +19,6 @@ const generator: GroupGenerator = {
     
     const tokenProviderData0 = await tokenProvider.getERC20Holders({
       contractAddress: "0x758B4684BE769E92eeFeA93f60DDA0181eA303Ec",
-      tokenDecimals: 18,
     });
 
     return [

--- a/group-generators/generators/hold-ape/index.ts
+++ b/group-generators/generators/hold-ape/index.ts
@@ -19,7 +19,6 @@ const generator: GroupGenerator = {
     
     const tokenProviderData0 = await tokenProvider.getERC20Holders({
       contractAddress: "0x4d224452801ACEd8B2F0aebE155379bb5D594381",
-      tokenDecimals: 18,
     });
 
     return [

--- a/group-generators/generators/pal-holders/index.ts
+++ b/group-generators/generators/pal-holders/index.ts
@@ -20,7 +20,6 @@ const generator: GroupGenerator = {
     const tokenProviderData0 = await tokenProvider.getERC20Holders({
       contractAddress: "0xAB846Fb6C81370327e784Ae7CbB6d6a6af6Ff4BF",
       network: "mainnet",
-      tokenDecimals: 18,
     });
 
     return [

--- a/group-generators/generators/pal-mainnet-holders/index.ts
+++ b/group-generators/generators/pal-mainnet-holders/index.ts
@@ -19,7 +19,6 @@ const generator: GroupGenerator = {
     
     const tokenProviderData0 = await tokenProvider.getERC20Holders({
       contractAddress: "0xAB846Fb6C81370327e784Ae7CbB6d6a6af6Ff4BF",
-      tokenDecimals: 18,
       network: "mainnet"
     });
 

--- a/group-generators/generators/phonon-mainnet-holders/index.ts
+++ b/group-generators/generators/phonon-mainnet-holders/index.ts
@@ -19,7 +19,6 @@ const generator: GroupGenerator = {
     
     const tokenProviderData0 = await tokenProvider.getERC20Holders({
       contractAddress: "0x758B4684BE769E92eeFeA93f60DDA0181eA303Ec",
-      tokenDecimals: 18,
     });
 
     return [

--- a/group-generators/generators/polygon-cake-holders/index.ts
+++ b/group-generators/generators/polygon-cake-holders/index.ts
@@ -10,16 +10,15 @@ import {
 // Generated from factory.sismo.io
 
 const generator: GroupGenerator = {
-  
+
   generationFrequency: GenerationFrequency.Once,
-  
+
   generate: async (context: GenerationContext): Promise<GroupWithData[]> => {
-  
+
     const tokenProvider = new dataProviders.TokenProvider();
-    
+
     const tokenProviderData0 = await tokenProvider.getERC20Holders({
       contractAddress: "0x805262B407177c3a4AA088088c571164F645c5D0",
-      tokenDecimals: 18,
       network: "polygon"
     });
 

--- a/group-generators/helpers/data-providers/token-provider/index.ts
+++ b/group-generators/helpers/data-providers/token-provider/index.ts
@@ -32,13 +32,12 @@ export class TokenProvider {
     const data: FetchedData = {};
     for (const key of Object.keys(rawData)) {
       const value = BigNumber.from(rawData[key]);
-      if(minAmount) {
+      if (minAmount) {
         const minAmountBig = BigNumber.from(minAmount);
         if (value.gte(minAmountBig)) {
           data[key] = forcedValue ?? BigNumber.from(rawData[key]).toString();
         }
-      }
-      else {
+      } else {
         data[key] = forcedValue ?? BigNumber.from(rawData[key]).toString();
       }
     }
@@ -67,20 +66,18 @@ export class TokenProvider {
 
   public async getERC20Holders({
     contractAddress,
-    tokenDecimals,
     network,
     minAmount,
     forcedValue,
-    snapshot
+    snapshot,
   }: {
     contractAddress: string;
     tokenDecimals?: number;
     network?: string;
-    minAmount?: number;
+    minAmount?: string;
     forcedValue?: number;
     snapshot?: string;
   }): Promise<FetchedData> {
-
     // Get token holders
     const bigQueryProvider = new BigQueryProvider({
       network: fromStringToSupportedNetwork(network ?? SupportedNetwork.MAINNET),
@@ -94,13 +91,11 @@ export class TokenProvider {
     const data: FetchedData = {};
     for (const key of Object.keys(rawData)) {
       const value = BigNumber.from(rawData[key]);
-      if(minAmount && tokenDecimals) {
-        const minAmountBig = BigNumber.from(minAmount).mul(BigNumber.from(10).pow(tokenDecimals));
-        if (value.gte(minAmountBig)) {
+      if (minAmount) {
+        if (value.gte(BigNumber.from(minAmount))) {
           data[key] = forcedValue ?? BigNumber.from(rawData[key]).toString();
         }
-      }
-      else {
+      } else {
         data[key] = forcedValue ?? BigNumber.from(rawData[key]).toString();
       }
     }
@@ -115,7 +110,7 @@ export class TokenProvider {
   }: {
     contractAddress: string;
     network?: string;
-    minAmount?: number;
+    minAmount?: string;
     snapshot?: string;
   }): Promise<number> {
     const data = await this.getERC20Holders({
@@ -154,11 +149,10 @@ export class TokenProvider {
     const data: FetchedData = {};
     for (const key of Object.keys(rawData)) {
       if (minAmount) {
-        if(BigNumber.from(rawData[key]).gte(minAmount)){
+        if (BigNumber.from(rawData[key]).gte(minAmount)) {
           data[key] = forcedValue ?? BigNumber.from(rawData[key]).toString();
         }
-      }
-      else if (BigNumber.from(rawData[key]).gt(0)) {
+      } else if (BigNumber.from(rawData[key]).gt(0)) {
         data[key] = forcedValue ?? BigNumber.from(rawData[key]).toString();
       }
     }

--- a/group-generators/helpers/data-providers/token-provider/index.ts
+++ b/group-generators/helpers/data-providers/token-provider/index.ts
@@ -72,7 +72,6 @@ export class TokenProvider {
     snapshot,
   }: {
     contractAddress: string;
-    tokenDecimals?: number;
     network?: string;
     minAmount?: string;
     forcedValue?: number;

--- a/group-generators/helpers/data-providers/token-provider/interface-schema.json
+++ b/group-generators/helpers/data-providers/token-provider/interface-schema.json
@@ -18,14 +18,6 @@
           "required": "true"
         },
         {
-          "name": "Token decimals",
-          "argName": "tokenDecimals",
-          "type": "number",
-          "example": "18",
-          "description": "The number of decimals of the ERC20 token contract",
-          "required": "true"
-        },
-        {
           "name": "Network",
           "argName": "network",
           "type": "string",


### PR DESCRIPTION
The `tokenDecimals` parameter was only used in the case there were a `minAmount` parameter set too (it was used to convert the minAmount into a non-wei number).
Because the token balance is now in wei, I think it makes more sense to have the minAmount also in wei. So we can also remove the `tokenDecimals` parameter