### PR TITLE
fix: make-groups-available command in send-on-chain github action (heap

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "cli": "node --require ts-node/register/transpile-only src/cli/cli.ts",
     "api": "node --require ts-node/register/transpile-only src/cli/cli.ts api",
     "api:watch": "nodemon --ignore 'disk-store' src/cli/cli.ts api",
-    "make-groups-available": "node --require ts-node/register/transpile-only src/cli/cli.ts make-groups-available",
+    "make-groups-available": "node --require --max-old-space-size=8192 ts-node/register/transpile-only src/cli/cli.ts make-groups-available",
     "generate-group": "node --require ts-node/register/transpile-only src/cli/cli.ts generate-group",
     "generate-all-groups": "node --require --max-old-space-size=4096 ts-node/register/transpile-only src/cli/cli.ts generate-all-groups",
     "update-groups-metadata": "node --require ts-node/register/transpile-only src/cli/cli.ts update-groups-metadata",


### PR DESCRIPTION
allocation limit)