### PR TITLE
feat: add `base` and `base_goerli` networks for Ankr Provider

### DIFF
--- a/group-generators/helpers/data-providers/ankr/interface-schema.json
+++ b/group-generators/helpers/data-providers/ankr/interface-schema.json
@@ -20,8 +20,8 @@
           "name": "Network",
           "argName": "network",
           "type": "string",
-          "example": "eth, 1, bsc, 56...",
-          "description": "The network name or ID where the Token is located. Network accepted: eth, bsc, fantom, avalanche, polygon, arbitrum, syscoin, optimism, eth_goerli, polygon_mumbai, avalanche_fuji"
+          "example": "eth, 1, base, 8453...",
+          "description": "The network name or ID where the Token is located. Network accepted: eth, base, bsc, fantom, avalanche, polygon, arbitrum, syscoin, optimism, eth_goerli, base_goerli, polygon_mumbai, avalanche_fuji"
         }
       ]
     },
@@ -42,8 +42,8 @@
           "name": "Network",
           "argName": "network",
           "type": "string",
-          "example": "eth, 1, bsc, 56...",
-          "description": "The network name or ID where the Token is located. Network accepted: eth, bsc, fantom, avalanche, polygon, arbitrum, syscoin, optimism, eth_goerli, polygon_mumbai, avalanche_fuji"
+          "example": "eth, 1, base, 8453...",
+          "description": "The network name or ID where the Token is located. Network accepted: eth, base, bsc, fantom, avalanche, polygon, arbitrum, syscoin, optimism, eth_goerli, base_goerli, polygon_mumbai, avalanche_fuji"
         }
       ]
     }

--- a/group-generators/helpers/data-providers/ankr/types.ts
+++ b/group-generators/helpers/data-providers/ankr/types.ts
@@ -5,6 +5,7 @@ export type TokenInfo = {
 
 export enum SupportedNetwork {
   ETH = "eth",
+  BASE = "base",
   BSC = "bsc",
   FANTOM = "fantom",
   AVALANCHE = "avalanche",
@@ -13,8 +14,9 @@ export enum SupportedNetwork {
   SYSCOIN = "syscoin",
   OPTIMISM = "optimism",
   ETH_GOERLI = "eth_goerli",
+  BASE_GOERLI = "base_goerli",
   POLYGON_MUMBAI = "polygon_mumbai",
-  AVALANCHE_FUJI = "avalanche_fuji"
+  AVALANCHE_FUJI = "avalanche_fuji",
 }
 
 export const fromStringToSupportedNetwork = (network: string): SupportedNetwork => {
@@ -22,6 +24,9 @@ export const fromStringToSupportedNetwork = (network: string): SupportedNetwork 
     case "eth":
     case "1":
       return SupportedNetwork.ETH;
+    case "base":
+    case "8453":
+      return SupportedNetwork.BASE;
     case "bsc":
     case "56":
       return SupportedNetwork.BSC;
@@ -46,6 +51,9 @@ export const fromStringToSupportedNetwork = (network: string): SupportedNetwork 
     case "eth_goerli":
     case "5":
       return SupportedNetwork.ETH_GOERLI;
+    case "base_goerli":
+    case "84531":
+      return SupportedNetwork.BASE_GOERLI;
     case "polygon_mumbai":
     case "80001":
       return SupportedNetwork.POLYGON_MUMBAI;


### PR DESCRIPTION
## Context

Add `base` and `base_goerli` networks to the Ankr Provider. This addition benefits both developers and Factory users.

- [x] add `base` and `base_goerli` in supported networks for Ankr Provider
- [x] update Ankr Provider interface for Factory users