### PR TITLE
chore: update group frequency sismo-contibutors ter1/tier2

### DIFF
--- a/group-generators/generators/sismo-contributors-tier1-users/index.ts
+++ b/group-generators/generators/sismo-contributors-tier1-users/index.ts
@@ -4,7 +4,7 @@ import { Tags, ValueType, GroupWithData, AccountSource, GroupStore } from "topic
 import { GenerationContext, GenerationFrequency, GroupGenerator } from "topics/group-generator";
 
 const generator: GroupGenerator = {
-  generationFrequency: GenerationFrequency.Daily,
+  generationFrequency: GenerationFrequency.Once,
   dependsOn: ["sismo-gen-zero"],
 
   generate: async (

--- a/group-generators/generators/sismo-contributors-tier2-impactful-contributors/index.ts
+++ b/group-generators/generators/sismo-contributors-tier2-impactful-contributors/index.ts
@@ -4,7 +4,7 @@ import { Tags, ValueType, GroupWithData, AccountSource, GroupStore } from "topic
 import { GenerationContext, GenerationFrequency, GroupGenerator } from "topics/group-generator";
 
 const generator: GroupGenerator = {
-  generationFrequency: GenerationFrequency.Daily,
+  generationFrequency: GenerationFrequency.Once,
   dependsOn: ["sismo-gen-a", "sismo-gen-x", "sismo-events", "sismo-gitcoin-donors"],
 
   generate: async (


### PR DESCRIPTION
## Context

Badges are now deprecated, we change the group frequency of `sismo-contributors-tier1` and `sismo-contributors-tier2` to `Once` to avoid querying Sismo Subgraphs.