### PR TITLE
chore: deprecate Scroll Alpha Testnet

### DIFF
--- a/.github/workflows/generate_group_prod.yml
+++ b/.github/workflows/generate_group_prod.yml
@@ -31,7 +31,7 @@ jobs:
           sh-group-generator-name: ${{ inputs.group-generator-name }}
           sh-attesters: hydra-s1-accountbound
           sh-attesters-networks: polygon gnosis
-          sh-registry-tree-networks: polygon mumbai mainnet goerli sepolia optimism optimism-goerli arbitrum-one arbitrum-goerli scroll-testnet base base-goerli gnosis
+          sh-registry-tree-networks: polygon mumbai mainnet goerli sepolia optimism optimism-goerli arbitrum-one arbitrum-goerli base base-goerli gnosis
           hive-api-key: ${{ secrets.HIVE_API_KEY }}
           alchemy-api-key: ${{ secrets.ALCHEMY_API_KEY }}
           json-rpc-url: ${{ secrets.JSON_RPC_URL }}

--- a/.github/workflows/generate_groups_send_on_chain_prod.yml
+++ b/.github/workflows/generate_groups_send_on_chain_prod.yml
@@ -104,7 +104,6 @@ jobs:
             optimism-goerli,
             arbitrum-one,
             arbitrum-goerli,
-            scroll-testnet,
             base,
             base-goerli,
           ]

--- a/.github/workflows/remove_groups_prod.yml
+++ b/.github/workflows/remove_groups_prod.yml
@@ -30,5 +30,5 @@ jobs:
           roots-registry-owner-mnemonic: ${{ secrets.ROOTS_REGISTRY_OWNER_MNEMONIC }}
           sh-additional-data: ${{ env.ADDITIONAL_DATA }}
           sh-attesters-networks: polygon gnosis
-          sh-registry-tree-networks: polygon mumbai mainnet goerli sepolia optimism optimism-goerli arbitrum-one arbitrum-goerli scroll-testnet base base-goerli gnosis
+          sh-registry-tree-networks: polygon mumbai mainnet goerli sepolia optimism optimism-goerli arbitrum-one arbitrum-goerli base base-goerli gnosis
           sh-attesters: hydra-s1-accountbound

--- a/.github/workflows/update_groups_daily_prod.yml
+++ b/.github/workflows/update_groups_daily_prod.yml
@@ -103,7 +103,6 @@ jobs:
             optimism-goerli,
             arbitrum-one,
             arbitrum-goerli,
-            scroll-testnet,
             base,
             base-goerli,
           ]

--- a/.github/workflows/update_groups_weekly_prod.yml
+++ b/.github/workflows/update_groups_weekly_prod.yml
@@ -32,7 +32,7 @@ jobs:
           google-application-credentials: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
           sh-attesters: hydra-s1-accountbound
           sh-attesters-networks: polygon gnosis
-          sh-registry-tree-networks: polygon mumbai mainnet goerli sepolia optimism optimism-goerli arbitrum-one arbitrum-goerli scroll-testnet base base-goerli gnosis
+          sh-registry-tree-networks: polygon mumbai mainnet goerli sepolia optimism optimism-goerli arbitrum-one arbitrum-goerli base base-goerli gnosis
           sh-ignore-resolving-errors: "true"
           hive-api-key: ${{ secrets.HIVE_API_KEY }}
           alchemy-api-key: ${{ secrets.ALCHEMY_API_KEY }}


### PR DESCRIPTION
## Context

Scroll Alpha Testnet has been deprecated by the Scroll team https://guide.scroll.io/user-guide/bridge/deposit-from-goerli-to-scroll. Therefore, we will not update any roots on the Scroll Alpha Testnet anymore. 

## todo

- [x] Removed `scroll-testnet` updates from workflows 