### PR TITLE
fix: remove `cli` command in workflows to increase the `max-old-space-size` used by node

### DIFF
--- a/.github/actions/generate-groups/action.yml
+++ b/.github/actions/generate-groups/action.yml
@@ -165,5 +165,5 @@ runs:
         if [[ -n "${{ inputs.sh-group-generator-name }}" ]]; then
           yarn generate-group ${{ inputs.sh-group-generator-name }} --storage-type aws
         else
-          yarn cli generate-all-groups --storage-type aws
+          yarn generate-all-groups --storage-type aws
         fi

--- a/.github/actions/update-groups-send-on-chain/action.yml
+++ b/.github/actions/update-groups-send-on-chain/action.yml
@@ -160,7 +160,7 @@ runs:
         TELEGRAM_BOT_SESSION: ${{ inputs.telegram-bot-session }}
         ROCI_API_KEY: ${{ inputs.roci-api-key }}
       run: |
-        yarn cli generate-all-groups --storage-type aws --logger-type local-file
+        yarn generate-all-groups --storage-type aws --logger-type local-file
 
     - name: keep only interesting logs
       shell: bash


### PR DESCRIPTION
## Context

Update workflows were failing due to using `yarn cli <command>` instead of `yarn <command>`. By using the command directly referenced in `package.json` we are specifying the extra memory allocation properly for the workflow.